### PR TITLE
fix nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,25 @@ A framework for creating conditional trading intents with the following componen
 - [move-intent-framework README](move-intent-framework/README.md)
 - [trusted verifier](trusted-verifier/docs/README.md)
 
+## Quick start
+
+- Enter dev shell with pinned toolchain (Rust, Aptos CLI):
+
+```
+nix develop
+```
+
+### Testing
+
+```
+cd move-intent-framework && aptos move test --dev --named-addresses aptos_intent=0x123 && cd ..
+
+# the following test is also required for the trusted-verifier integration test
+./trusted-verifier/tests/integration/run-cross-chain-verifier.sh 1
+
+cd trusted-verifier && cargo test --locked && cd ..
+```
+
 ## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/aptos.nix
+++ b/aptos.nix
@@ -6,15 +6,18 @@ let
     else if stdenv.isLinux then "Ubuntu"
     else throw "Unsupported platform ${stdenv.system}";
 
-  sha256 = if os == "MacOSX" then "sha256-6uVxfgcFgxgwF9vwQwaTt23IbV5vNACmjN9BO6TSQ20="
-            else "sha256-Uz3fkyj7SlBKKKi8bl3eNvQ6HiGnEE/UO362jiEWpTo=";
+  # Aptos CLI v7.10.2 release asset hashes (base64 Nix form)
+  sha256 = if os == "MacOSX" then "sha256-cM/70SrBkBZB+hsyByAlHjBKVy6wFk0A6jE6MaZauEI="
+            else "sha256-ZS+tWYCKbBynbUua0jvhOv++a03Ho625kj3ldUJRB80=";
 
 in stdenv.mkDerivation rec {
   pname = "aptos-cli";
-  version = "4.3.0";
+  version = "7.10.2";
 
   src = fetchurl {
-    url = "https://github.com/aptos-labs/aptos-core/releases/download/${pname}-v${version}/${pname}-${version}-${os}-x86_64.zip";
+    url = if os == "MacOSX"
+      then "https://github.com/aptos-labs/aptos-core/releases/download/${pname}-v${version}/${pname}-${version}-macOS-x86_64.zip"
+      else "https://github.com/aptos-labs/aptos-core/releases/download/${pname}-v${version}/${pname}-${version}-Ubuntu-22.04-x86_64.zip";
     sha256 = sha256;
   };
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761672384,
+        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "Intent Framework dev shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        aptosCli = pkgs.callPackage ./aptos.nix {};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.rustc
+            pkgs.cargo
+            pkgs.rustfmt
+            pkgs.clippy
+            pkgs.jq
+            pkgs.curl
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.openssl
+            pkgs.pkg-config
+            aptosCli
+          ];
+
+          shellHook = ''
+            echo "[nix] Dev shell ready: rustc $(rustc --version | awk '{print $2}') | cargo $(cargo --version | awk '{print $2}') | aptos $(aptos --version 2>/dev/null || echo 'unknown')"
+            export OPENSSL_DIR=${pkgs.openssl.dev}
+            export OPENSSL_LIB_DIR=${pkgs.openssl.out}/lib
+            export OPENSSL_INCLUDE_DIR=${pkgs.openssl.dev}/include
+          '';
+        };
+      }
+    );
+}

--- a/move-intent-framework/Move.toml
+++ b/move-intent-framework/Move.toml
@@ -6,12 +6,14 @@ authors = []
 [addresses]
 aptos_intent = "_"
 
-[dev-addresses]
-aptos_intent = "0x123"
-
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
-rev = "mainnet"
+rev = "a10a3c02f16a2114ad065db6b4a525f0382e96a6"
 subdir = "aptos-framework"
 
 [dev-dependencies]
+
+[dev-dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-framework.git"
+rev = "a10a3c02f16a2114ad065db6b4a525f0382e96a6"
+subdir = "aptos-framework"

--- a/move-intent-framework/README.md
+++ b/move-intent-framework/README.md
@@ -85,7 +85,7 @@ nix-shell
 pub  # This runs: aptos move publish --named-addresses aptos_intent=$intent
 
 # 5. Verify deployment
-aptos move test --dev
+aptos move test --dev --named-addresses aptos_intent=0x123
 ```
 
 **Note**: The `pub` command deploys to whatever network your Aptos CLI is configured for. For local development, you must first configure Aptos CLI to point to your local Docker chain (port 8080) using `aptos init --profile local --network local`.

--- a/move-intent-framework/docs/development.md
+++ b/move-intent-framework/docs/development.md
@@ -29,7 +29,7 @@ This document covers development setup, testing, configuration, and dependencies
 
 Run all tests with:
 ```bash
-aptos move test --dev
+aptos move test --dev --named-addresses aptos_intent=0x123
 ```
 
 ### Test Structure
@@ -56,13 +56,13 @@ The test suite includes:
 
 ```bash
 # Run only intent tests
-aptos move test --dev --filter intent_tests
+aptos move test --dev --named-addresses aptos_intent=0x123 --filter intent_tests
 
 # Run only fungible asset tests
-aptos move test --dev --filter fa_tests
+aptos move test --dev --named-addresses aptos_intent=0x123 --filter fa_tests
 
 # Run only reservation tests
-aptos move test --dev --filter intent_reservation_tests
+aptos move test --dev --named-addresses aptos_intent=0x123 --filter intent_reservation_tests
 ```
 
 ## Configuration

--- a/move-intent-framework/shell.nix
+++ b/move-intent-framework/shell.nix
@@ -15,7 +15,7 @@ pkgs.mkShell {
       nodemon \
         --ignore build/* \
         --ext move \
-        --exec "aptos move test --dev --skip-fetch-latest-git-deps;"
+        --exec "aptos move test --dev --named-addresses aptos_intent=0x123 --skip-fetch-latest-git-deps;"
     }
 
     pub() {

--- a/move-intent-framework/tests/cross_chain/setup-and-deploy.sh
+++ b/move-intent-framework/tests/cross_chain/setup-and-deploy.sh
@@ -40,7 +40,7 @@ CHAIN1_ADDRESS=$(aptos config show-profiles | jq -r '.["Result"]["intent-account
 
 echo "   - Deploying to Chain 1 with address: $CHAIN1_ADDRESS"
 cd move-intent-framework
-aptos move publish --profile intent-account-chain1 --named-addresses aptos_intent=$CHAIN1_ADDRESS --assume-yes
+aptos move publish --dev --profile intent-account-chain1 --named-addresses aptos_intent=$CHAIN1_ADDRESS --assume-yes
 
 if [ $? -eq 0 ]; then
     echo "   ✅ Chain 1 deployment successful!"
@@ -57,7 +57,7 @@ CHAIN2_ADDRESS=$(aptos config show-profiles | jq -r '.["Result"]["intent-account
 
 echo "   - Deploying to Chain 2 with address: $CHAIN2_ADDRESS"
 cd move-intent-framework
-aptos move publish --profile intent-account-chain2 --named-addresses aptos_intent=$CHAIN2_ADDRESS --assume-yes
+aptos move publish --dev --profile intent-account-chain2 --named-addresses aptos_intent=$CHAIN2_ADDRESS --assume-yes
 
 if [ $? -eq 0 ]; then
     echo "   ✅ Chain 2 deployment successful!"


### PR DESCRIPTION
## Update Nix Flake Integration and Aptos CLI Version

### Overview
This PR introduces a consistent, reproducible Nix-based development environment for the Intent Framework, aligning the toolchain and Aptos CLI version across macOS and Linux. It ensures all Move and Rust tooling can be pinned and built via `nix develop` with minimal setup friction.

### Changes
**Nix Integration**
- Added `flake.nix` and `flake.lock` for declarative environment management.  
- Integrated `flake-utils` and `nixpkgs` for multi-system compatibility.  
- Defined a `devShell` including Rust toolchain, Aptos CLI, and standard utilities.

**Aptos CLI**
- Bumped from `4.3.0` → `7.10.2`.  
- Adjusted platform-specific SHA256 hashes and download URLs for both macOS and Ubuntu.  
- Updated `aptos.nix` to fetch platform-specific binaries.

### Testing
```bash
nix develop
cd move-intent-framework && aptos move test --dev --named-addresses aptos_intent=0x123
./trusted-verifier/tests/integration/run-cross-chain-verifier.sh 1
cd trusted-verifier && cargo test --locked
