### PR TITLE
security: Require reserved solver addresses for all escrows

### DIFF
--- a/.taskmaster/CLAUDE.md
+++ b/.taskmaster/CLAUDE.md
@@ -158,9 +158,23 @@ task-master show <id>                     # Review task details
 # During implementation, check in code context into the tasks and subtasks
 task-master update-subtask --id=<id> --prompt="implementation notes..."
 
-# Complete tasks
+# Complete subtasks and tasks
 task-master set-status --id=<id> --status=done
+
+# IMPORTANT: Commit after each subtask and task completion
+# After marking a subtask or task as done, create a commit with the changes
+git commit -m "<type of change>: <description>
+
+- <more detailed points if needed (optional)>
+- <more detailed points if needed (optional)>
+"
 ```
+
+**Commit Rule:**
+- **ALWAYS commit after completing each subtask or task** - This ensures incremental progress is saved
+- **Do NOT run `git add`** - Files should already be staged by the user before committing
+- Don't mention the subtask or task ID in the commit message.
+- Run tests before committing to ensure the changes work correctly
 
 #### 3. Multi-Claude Workflows
 

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -1,97 +1,11 @@
 {
   "master": {
-    "tasks": [
-      {
-        "id": "1",
-        "title": "Fix signature replay vulnerability by requiring reserved solver in escrow",
-        "description": "Fix critical security vulnerability where verifier signatures don't bind to solver addresses by requiring all escrows to specify a reserved solver address. The solver address is stored in the escrow at creation time and is mandatory (not optional). When claiming, the escrow enforces that funds are transferred to the reserved solver address. Anyone can send the claim transaction, but the funds must always go to the reserved solver. This matches the Move intent reservation pattern where IntentReserved stores the solver address.",
-        "status": "done",
-        "dependencies": [],
-        "priority": "medium",
-        "details": "**CRITICAL SECURITY ISSUE**: Current verifier signatures only include (intentId, approvalValue) in the signed message, making them reusable by any solver who obtains a valid signature. This allows unauthorized escrow claims.\n\n**New Approach - Required Reserved Escrows:**\nInstead of modifying verifier signatures to include solver addresses, require all escrows to specify a reserved solver address. The solver address is stored in the escrow struct at creation time and is mandatory (not optional). The verifier signature format remains unchanged - it just approves/rejects the intent - but the on-chain logic enforces that funds are always transferred to the reserved solver address. Anyone can send the claim transaction, but the recipient must always be the reserved solver.\n\n**Files to Modify:**\n\n**1. EVM Contract (evm-intent-framework/contracts/IntentEscrow.sol)**:\n- Add required `reservedSolver` field to Escrow struct to store the receiving solver address\n- Update `createEscrow()` to require reserved solver address parameter (must not be address(0))\n- Store the solver address in the escrow when created\n- Modify `claim()` function to always transfer funds to `escrow.reservedSolver` (not msg.sender)\n- Add require check: `require(reservedSolver != address(0), \"Reserved solver must be specified\")`\n- Keep verifier signature format unchanged: keccak256(abi.encodePacked(intentId, approvalValue))\n\n**2. Aptos Move Contracts**:\n- Leverage existing intent_reservation.move system where IntentReserved struct stores the solver address\n- Update intent_as_escrow.move to require IntentReserved (not Optional<IntentReserved>)\n- The IntentReserved struct stores the solver address that should receive the funds\n- Modify `create_escrow_from_fa()` in intent_as_escrow_entry.move to require reserved_solver parameter\n- Modify `complete_escrow()` to deposit escrowed assets to the reserved solver address from IntentReserved\n- Access the IntentReserved from the TradeIntent to get the solver address\n- Keep verifier signature format unchanged for Ed25519 signatures\n\n**3. API Updates**:\n- Update escrow creation endpoints to require `reservedSolver` parameter\n- No changes needed to verifier signature endpoints - they remain the same\n- Update E2E test scripts to always specify a reserved solver address\n\n**Security Benefits:**\n- Prevents signature replay attacks by requiring all escrows to specify a solver address\n- The escrow itself stores which solver receives the funds, making the restriction on-chain and enforceable\n- Anyone can send the claim transaction, but funds always go to the reserved solver\n- Matches existing Move reservation pattern where IntentReserved stores the solver address\n- No changes needed to verifier service signature creation logic",
-        "testStrategy": "1. Create unit tests for escrows with required reserved solver address on both EVM and Aptos\n2. Test that escrows always transfer funds to the reserved solver address, regardless of who sends the transaction\n3. Test that createEscrow/create_escrow_from_fa requires a solver address (reverts if address(0) or missing)\n4. Verify existing verifier signature format works unchanged\n5. Test edge cases: different accounts sending claim transaction, but funds always go to reserved solver\n6. Run security audit tests to confirm vulnerability is addressed by requiring reserved solver\n7. Test cross-chain scenarios with escrows that have reserved solvers\n8. Update all existing tests to specify reserved solver addresses",
-        "subtasks": [
-          {
-            "id": 1,
-            "title": "Add required reserved solver field to EVM IntentEscrow contract",
-            "description": "Modify the Escrow struct in IntentEscrow.sol to include a required reservedSolver field that stores which solver address can receive/claim the escrow, and update createEscrow function to require this parameter.",
-            "dependencies": [],
-            "details": "Update the Escrow struct in evm-intent-framework/contracts/IntentEscrow.sol to add:\n- `address reservedSolver` field that stores which solver address receives the funds when escrow is claimed (address(0) means unreserved, funds go to msg.sender)\n- Modify `createEscrow()` function signature to accept optional `address reservedSolver` parameter\n- Store the reservedSolver address in the escrow struct during escrow creation\n- Update events to include the listed solver address (reservation status)",
-            "status": "done",
-            "testStrategy": "Unit tests for createEscrow with listed solver address and without (unreserved)",
-            "parentId": "undefined",
-            "updatedAt": "2025-11-10T08:20:17.393Z"
-          },
-          {
-            "id": 2,
-            "title": "Implement solver recipient check in EVM claim function",
-            "description": "Update the claim() function in IntentEscrow.sol to transfer funds to the solver address listed in the escrow (if one is listed), rather than always transferring to msg.sender.",
-            "dependencies": [
-              1
-            ],
-            "details": "Modify the `claim()` function in evm-intent-framework/contracts/IntentEscrow.sol:108-150 to:\n- Check if `escrow.reservedSolver != address(0)` (escrow lists a specific solver)\n- If the escrow lists a solver, transfer funds to `escrow.reservedSolver` instead of `msg.sender`\n- If escrow does not list a solver (reservedSolver == address(0)), transfer to `msg.sender` as before\n- Anyone can send the transaction, but funds always go to the reserved solver if one is listed\n- Keep existing verifier signature verification unchanged\n- Update events to include the actual recipient address (reservedSolver or msg.sender)",
-            "status": "done",
-            "testStrategy": "Unit tests for claim function: funds go to reserved solver address when listed, regardless of who sends transaction. Test unreserved escrows transfer to msg.sender.",
-            "parentId": "undefined",
-            "updatedAt": "2025-11-10T08:26:18.658Z"
-          },
-          {
-            "id": 3,
-            "title": "Integrate Move intent reservation system with escrow contracts",
-            "description": "Update Aptos move contracts to use the existing intent_reservation.move system where IntentReserved stores the solver address that can claim the escrow.",
-            "dependencies": [],
-            "details": "Modify move-intent-framework/sources/intent_as_escrow.move to:\n- Import and use existing `intent_reservation::IntentReserved` system from intent_reservation.move:19\n- The IntentReserved struct stores the solver address (solver: address) that can claim the escrow\n- Update `create_escrow()` function to require reservation parameter (not Optional<IntentReserved>)\n- Store the IntentReserved (with solver address) in the escrow when created\n- Integrate with existing reservation verification in the Move framework\n- Use existing `intent_reservation::ensure_solver_authorized()` function to verify the solver matches the reserved address\n- Maintain compatibility with existing oracle signature system",
-            "status": "done",
-            "testStrategy": "Unit tests for escrow creation and completion with Move reservation system where IntentReserved stores the solver address",
-            "parentId": "undefined",
-            "updatedAt": "2025-11-10T09:08:33.893Z"
-          },
-          {
-            "id": 4,
-            "title": "Update Aptos escrow completion to transfer funds to reserved solver",
-            "description": "Modify the complete_escrow function to deposit escrowed assets to the solver address from the escrow's IntentReserved (which is now required), rather than the transaction signer.",
-            "dependencies": [
-              3
-            ],
-            "details": "Update `complete_escrow()` function in move-intent-framework/sources/intent_as_escrow.move to:\n- Access IntentReserved from the TradeSession (which is always present since escrows require reservations)\n- Deposit escrowed assets to `intent_reserved.solver` from the reservation\n- The `ensure_solver_authorized()` function already verifies the solver signer matches the reserved solver\n- Anyone can send the transaction, but funds always go to the reserved solver\n- Maintain existing verifier signature verification flow\n- Keep Ed25519 signature format unchanged\n- Update `create_escrow_from_fa()` to require reserved_solver parameter",
-            "status": "done",
-            "testStrategy": "Integration tests for escrow completion: funds always go to reserved solver address, regardless of who sends transaction",
-            "parentId": "undefined"
-          },
-          {
-            "id": 5,
-            "title": "Add comprehensive test coverage for reserved escrows",
-            "description": "Create extensive test suite covering escrows with required reserved solver addresses across EVM and Aptos implementations.",
-            "dependencies": [
-              2,
-              4
-            ],
-            "details": "Create comprehensive test coverage:\n- EVM tests: escrow creation with required reserved solver address, different accounts sending claim transaction but funds always go to reserved solver\n- EVM tests: verify that createEscrow reverts if reservedSolver is address(0)\n- Aptos tests: integration with IntentReserved system where escrow requires solver address, different accounts sending transaction but funds always go to reserved solver\n- Aptos tests: verify that create_escrow requires reservation parameter\n- Cross-chain tests: escrows with reserved solvers work correctly across both chains\n- Security tests: verify signature replay prevention (funds always go to reserved solver)\n- Edge case tests: verify all escrows must specify a solver address, state transitions",
-            "status": "done",
-            "testStrategy": "Full test suite covering escrows with required reserved solver addresses, including security and functionality testing",
-            "parentId": "undefined"
-          },
-          {
-            "id": 6,
-            "title": "Update E2E test scripts and documentation for required reserved escrows",
-            "description": "Update end-to-end test scripts and documentation to reflect that all escrows must specify a reserved solver address.",
-            "dependencies": [
-              5
-            ],
-            "details": "Update integration components:\n- Modify E2E test scripts to always specify a reserved solver address when creating escrows\n- Update API documentation to describe required reservedSolver parameter\n- Update examples to show escrow creation with reserved solver (no unreserved examples)\n- Update security documentation to explain how requiring a reserved solver prevents signature replay\n- Update all documentation to reflect that reservations are required, not optional\n- Remove references to unreserved escrows from documentation",
-            "status": "done",
-            "testStrategy": "E2E testing with escrows that have reserved solvers, documentation review",
-            "parentId": "undefined"
-          }
-        ],
-        "updatedAt": "2025-11-10T09:08:33.893Z"
-      }
-    ],
+    "tasks": [],
     "metadata": {
       "version": "1.0.0",
       "lastModified": "2025-11-10T09:08:33.894Z",
-      "taskCount": 1,
-      "completedCount": 1,
+      "taskCount": 0,
+      "completedCount": 0,
       "tags": [
         "master"
       ]

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -5,7 +5,7 @@
         "id": "1",
         "title": "Fix signature replay vulnerability by listing receiving solver in escrow",
         "description": "Fix critical security vulnerability where verifier signatures don't bind to solver addresses by implementing reserved escrows where the escrow lists which solver address can receive the funds. The solver address is stored in the escrow at creation time. When claiming, the escrow enforces that funds are transferred to the listed solver address (if one is listed). Anyone can send the claim transaction, but the funds must go to the reserved solver. This matches the Move intent reservation pattern where IntentReserved stores the solver address.",
-        "status": "pending",
+        "status": "in-progress",
         "dependencies": [],
         "priority": "medium",
         "details": "**CRITICAL SECURITY ISSUE**: Current verifier signatures only include (intentId, approvalValue) in the signed message, making them reusable by any solver who obtains a valid signature. This allows unauthorized escrow claims.\n\n**New Approach - Reserved Escrows:**\nInstead of modifying verifier signatures to include solver addresses, implement an optional reservation system where escrows store/list which solver address can receive the funds. The solver address is stored in the escrow struct at creation time. The verifier signature format remains unchanged - it just approves/rejects the intent - but the on-chain logic enforces that funds are transferred to the listed solver address (if one is listed). Anyone can send the claim transaction, but the recipient must be the reserved solver.\n\n**Files to Modify:**\n\n**1. EVM Contract (evm-intent-framework/contracts/IntentEscrow.sol)**:\n- Add optional `reservedSolver` field to Escrow struct to store the receiving solver address\n- Update `createEscrow()` to accept optional reserved solver address parameter\n- Store the solver address in the escrow when created (address(0) means unreserved)\n- Modify `claim()` function to check if escrow lists a solver and transfer funds to that listed solver address (not msg.sender)\n- If escrow lists a solver, transfer to `escrow.reservedSolver` instead of `msg.sender`\n- Keep verifier signature format unchanged: keccak256(abi.encodePacked(intentId, approvalValue))\n\n**2. Aptos Move Contracts**:\n- Leverage existing intent_reservation.move system where IntentReserved struct stores the solver address\n- Update intent_as_escrow.move to use Optional<IntentReserved> from the reservation system\n- The IntentReserved struct already stores the solver address that should receive the funds\n- Modify `complete_escrow_from_fa()` in intent_as_escrow_entry.move to deposit escrowed assets to the reserved solver address (if listed), not the transaction signer\n- Access the IntentReserved from the TradeIntent to get the solver address\n- No need to check transaction signer - just deposit to the reserved solver address\n- Keep verifier signature format unchanged for Ed25519 signatures\n\n**3. Optional API Updates**:\n- Add optional `reservedSolver` parameter to escrow creation endpoints\n- No changes needed to verifier signature endpoints - they remain the same\n- Update E2E test scripts to test both reserved (with listed solver) and unreserved escrow scenarios\n\n**Security Benefits:**\n- Prevents signature replay attacks when escrows list a specific solver address\n- The escrow itself stores which solver receives the funds, making the restriction on-chain and enforceable\n- Anyone can send the claim transaction, but funds always go to the reserved solver (if listed)\n- Maintains backward compatibility - unreserved escrows (no listed solver) transfer to msg.sender as before\n- Matches existing Move reservation pattern where IntentReserved stores the solver address\n- No changes needed to verifier service signature creation logic",
@@ -17,19 +17,23 @@
             "description": "Modify the Escrow struct in IntentEscrow.sol to include an optional reservedSolver field that stores which solver address can receive/claim the escrow, and update createEscrow function to accept this parameter.",
             "dependencies": [],
             "details": "Update the Escrow struct in evm-intent-framework/contracts/IntentEscrow.sol to add:\n- `address reservedSolver` field that stores which solver address receives the funds when escrow is claimed (address(0) means unreserved, funds go to msg.sender)\n- Modify `createEscrow()` function signature to accept optional `address reservedSolver` parameter\n- Store the reservedSolver address in the escrow struct during escrow creation\n- Update events to include the listed solver address (reservation status)",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "Unit tests for createEscrow with listed solver address and without (unreserved)",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2025-11-10T08:20:17.393Z"
           },
           {
             "id": 2,
             "title": "Implement solver recipient check in EVM claim function",
             "description": "Update the claim() function in IntentEscrow.sol to transfer funds to the solver address listed in the escrow (if one is listed), rather than always transferring to msg.sender.",
-            "dependencies": [1],
+            "dependencies": [
+              1
+            ],
             "details": "Modify the `claim()` function in evm-intent-framework/contracts/IntentEscrow.sol:108-150 to:\n- Check if `escrow.reservedSolver != address(0)` (escrow lists a specific solver)\n- If the escrow lists a solver, transfer funds to `escrow.reservedSolver` instead of `msg.sender`\n- If escrow does not list a solver (reservedSolver == address(0)), transfer to `msg.sender` as before\n- Anyone can send the transaction, but funds always go to the reserved solver if one is listed\n- Keep existing verifier signature verification unchanged\n- Update events to include the actual recipient address (reservedSolver or msg.sender)",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "Unit tests for claim function: funds go to reserved solver address when listed, regardless of who sends transaction. Test unreserved escrows transfer to msg.sender.",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2025-11-10T08:26:18.658Z"
           },
           {
             "id": 3,
@@ -45,7 +49,9 @@
             "id": 4,
             "title": "Update Aptos escrow completion to transfer funds to reserved solver",
             "description": "Modify the complete_escrow_from_fa function to deposit escrowed assets to the solver address listed in the escrow's IntentReserved (if one is listed), rather than the transaction signer.",
-            "dependencies": [3],
+            "dependencies": [
+              3
+            ],
             "details": "Update `complete_escrow_from_fa()` function in move-intent-framework/sources/intent_as_escrow_entry.move:59-84 to:\n- Check if escrow has IntentReserved (reservation parameter)\n- If IntentReserved exists, deposit escrowed assets to `intent_reserved.solver` instead of `signer::address_of(solver)` (line 74)\n- If no IntentReserved, deposit to transaction signer as before\n- Anyone can send the transaction, but funds always go to the reserved solver if one is listed\n- Maintain existing verifier signature verification flow\n- Ensure unreserved escrows (no IntentReserved) continue to work by depositing to transaction signer\n- Keep Ed25519 signature format unchanged",
             "status": "pending",
             "testStrategy": "Integration tests for escrow completion: funds go to reserved solver address when listed, regardless of who sends transaction. Test unreserved escrows deposit to transaction signer.",
@@ -55,7 +61,10 @@
             "id": 5,
             "title": "Add comprehensive test coverage for reserved vs unreserved escrows",
             "description": "Create extensive test suite covering both escrows that list a specific solver address and unreserved escrows (no listed solver) across EVM and Aptos implementations.",
-            "dependencies": [2, 4],
+            "dependencies": [
+              2,
+              4
+            ],
             "details": "Create comprehensive test coverage:\n- EVM tests: escrow creation with listed solver address, different accounts sending claim transaction but funds always go to reserved solver\n- Aptos tests: integration with IntentReserved system where escrow stores solver address, different accounts sending transaction but funds always go to reserved solver\n- Cross-chain tests: escrows that list a solver address work correctly across both chains\n- Security tests: verify signature replay prevention when escrow lists a specific solver (funds always go to reserved solver)\n- Backward compatibility tests: unreserved escrows (no listed solver) transfer to msg.sender/transaction signer as before\n- Edge case tests: empty/zero address handling (unreserved), state transitions",
             "status": "pending",
             "testStrategy": "Full test suite covering escrows with listed solver address vs unreserved escrows, including security, functionality, and compatibility testing",
@@ -65,18 +74,21 @@
             "id": 6,
             "title": "Update E2E test scripts and documentation for reserved escrow feature",
             "description": "Update end-to-end test scripts and documentation to cover escrows that list a specific solver address while maintaining backward compatibility with unreserved escrows.",
-            "dependencies": [5],
+            "dependencies": [
+              5
+            ],
             "details": "Update integration components:\n- Modify E2E test scripts to test both escrows with listed solver address and unreserved escrows (no listed solver)\n- Update API documentation to describe optional reservedSolver parameter that stores which solver can claim the escrow\n- Add examples of creating escrows with listed solver vs unreserved escrows\n- Update security documentation to explain how listing a solver address in the escrow prevents signature replay\n- Ensure all existing E2E flows continue to work (backward compatibility for unreserved escrows)\n- Document migration path for applications wanting to use escrows that list a specific solver address",
             "status": "pending",
             "testStrategy": "E2E testing with escrows listing a solver address and unreserved escrows, documentation review",
             "parentId": "undefined"
           }
-        ]
+        ],
+        "updatedAt": "2025-11-10T08:26:18.658Z"
       }
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2025-11-08T22:36:26.230Z",
+      "lastModified": "2025-11-10T08:26:18.661Z",
       "taskCount": 1,
       "completedCount": 0,
       "tags": [

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -3,18 +3,18 @@
     "tasks": [
       {
         "id": "1",
-        "title": "Fix signature replay vulnerability by listing receiving solver in escrow",
-        "description": "Fix critical security vulnerability where verifier signatures don't bind to solver addresses by implementing reserved escrows where the escrow lists which solver address can receive the funds. The solver address is stored in the escrow at creation time. When claiming, the escrow enforces that funds are transferred to the listed solver address (if one is listed). Anyone can send the claim transaction, but the funds must go to the reserved solver. This matches the Move intent reservation pattern where IntentReserved stores the solver address.",
-        "status": "in-progress",
+        "title": "Fix signature replay vulnerability by requiring reserved solver in escrow",
+        "description": "Fix critical security vulnerability where verifier signatures don't bind to solver addresses by requiring all escrows to specify a reserved solver address. The solver address is stored in the escrow at creation time and is mandatory (not optional). When claiming, the escrow enforces that funds are transferred to the reserved solver address. Anyone can send the claim transaction, but the funds must always go to the reserved solver. This matches the Move intent reservation pattern where IntentReserved stores the solver address.",
+        "status": "done",
         "dependencies": [],
         "priority": "medium",
-        "details": "**CRITICAL SECURITY ISSUE**: Current verifier signatures only include (intentId, approvalValue) in the signed message, making them reusable by any solver who obtains a valid signature. This allows unauthorized escrow claims.\n\n**New Approach - Reserved Escrows:**\nInstead of modifying verifier signatures to include solver addresses, implement an optional reservation system where escrows store/list which solver address can receive the funds. The solver address is stored in the escrow struct at creation time. The verifier signature format remains unchanged - it just approves/rejects the intent - but the on-chain logic enforces that funds are transferred to the listed solver address (if one is listed). Anyone can send the claim transaction, but the recipient must be the reserved solver.\n\n**Files to Modify:**\n\n**1. EVM Contract (evm-intent-framework/contracts/IntentEscrow.sol)**:\n- Add optional `reservedSolver` field to Escrow struct to store the receiving solver address\n- Update `createEscrow()` to accept optional reserved solver address parameter\n- Store the solver address in the escrow when created (address(0) means unreserved)\n- Modify `claim()` function to check if escrow lists a solver and transfer funds to that listed solver address (not msg.sender)\n- If escrow lists a solver, transfer to `escrow.reservedSolver` instead of `msg.sender`\n- Keep verifier signature format unchanged: keccak256(abi.encodePacked(intentId, approvalValue))\n\n**2. Aptos Move Contracts**:\n- Leverage existing intent_reservation.move system where IntentReserved struct stores the solver address\n- Update intent_as_escrow.move to use Optional<IntentReserved> from the reservation system\n- The IntentReserved struct already stores the solver address that should receive the funds\n- Modify `complete_escrow_from_fa()` in intent_as_escrow_entry.move to deposit escrowed assets to the reserved solver address (if listed), not the transaction signer\n- Access the IntentReserved from the TradeIntent to get the solver address\n- No need to check transaction signer - just deposit to the reserved solver address\n- Keep verifier signature format unchanged for Ed25519 signatures\n\n**3. Optional API Updates**:\n- Add optional `reservedSolver` parameter to escrow creation endpoints\n- No changes needed to verifier signature endpoints - they remain the same\n- Update E2E test scripts to test both reserved (with listed solver) and unreserved escrow scenarios\n\n**Security Benefits:**\n- Prevents signature replay attacks when escrows list a specific solver address\n- The escrow itself stores which solver receives the funds, making the restriction on-chain and enforceable\n- Anyone can send the claim transaction, but funds always go to the reserved solver (if listed)\n- Maintains backward compatibility - unreserved escrows (no listed solver) transfer to msg.sender as before\n- Matches existing Move reservation pattern where IntentReserved stores the solver address\n- No changes needed to verifier service signature creation logic",
-        "testStrategy": "1. Create unit tests for escrows with listed solver address vs unreserved escrows on both EVM and Aptos\n2. Test that escrows listing a solver always transfer funds to that listed solver address, regardless of who sends the transaction\n3. Test that unreserved escrows (no listed solver) transfer funds to msg.sender (transaction sender) as before\n4. Verify existing verifier signature format works unchanged\n5. Test edge cases: different accounts sending claim transaction, but funds always go to reserved solver\n6. Run security audit tests to confirm vulnerability is addressed when escrow lists a specific solver\n7. Test cross-chain scenarios with both escrows listing a solver and unreserved escrows\n8. Ensure backward compatibility - existing unreserved escrows (no listed solver) continue to work",
+        "details": "**CRITICAL SECURITY ISSUE**: Current verifier signatures only include (intentId, approvalValue) in the signed message, making them reusable by any solver who obtains a valid signature. This allows unauthorized escrow claims.\n\n**New Approach - Required Reserved Escrows:**\nInstead of modifying verifier signatures to include solver addresses, require all escrows to specify a reserved solver address. The solver address is stored in the escrow struct at creation time and is mandatory (not optional). The verifier signature format remains unchanged - it just approves/rejects the intent - but the on-chain logic enforces that funds are always transferred to the reserved solver address. Anyone can send the claim transaction, but the recipient must always be the reserved solver.\n\n**Files to Modify:**\n\n**1. EVM Contract (evm-intent-framework/contracts/IntentEscrow.sol)**:\n- Add required `reservedSolver` field to Escrow struct to store the receiving solver address\n- Update `createEscrow()` to require reserved solver address parameter (must not be address(0))\n- Store the solver address in the escrow when created\n- Modify `claim()` function to always transfer funds to `escrow.reservedSolver` (not msg.sender)\n- Add require check: `require(reservedSolver != address(0), \"Reserved solver must be specified\")`\n- Keep verifier signature format unchanged: keccak256(abi.encodePacked(intentId, approvalValue))\n\n**2. Aptos Move Contracts**:\n- Leverage existing intent_reservation.move system where IntentReserved struct stores the solver address\n- Update intent_as_escrow.move to require IntentReserved (not Optional<IntentReserved>)\n- The IntentReserved struct stores the solver address that should receive the funds\n- Modify `create_escrow_from_fa()` in intent_as_escrow_entry.move to require reserved_solver parameter\n- Modify `complete_escrow()` to deposit escrowed assets to the reserved solver address from IntentReserved\n- Access the IntentReserved from the TradeIntent to get the solver address\n- Keep verifier signature format unchanged for Ed25519 signatures\n\n**3. API Updates**:\n- Update escrow creation endpoints to require `reservedSolver` parameter\n- No changes needed to verifier signature endpoints - they remain the same\n- Update E2E test scripts to always specify a reserved solver address\n\n**Security Benefits:**\n- Prevents signature replay attacks by requiring all escrows to specify a solver address\n- The escrow itself stores which solver receives the funds, making the restriction on-chain and enforceable\n- Anyone can send the claim transaction, but funds always go to the reserved solver\n- Matches existing Move reservation pattern where IntentReserved stores the solver address\n- No changes needed to verifier service signature creation logic",
+        "testStrategy": "1. Create unit tests for escrows with required reserved solver address on both EVM and Aptos\n2. Test that escrows always transfer funds to the reserved solver address, regardless of who sends the transaction\n3. Test that createEscrow/create_escrow_from_fa requires a solver address (reverts if address(0) or missing)\n4. Verify existing verifier signature format works unchanged\n5. Test edge cases: different accounts sending claim transaction, but funds always go to reserved solver\n6. Run security audit tests to confirm vulnerability is addressed by requiring reserved solver\n7. Test cross-chain scenarios with escrows that have reserved solvers\n8. Update all existing tests to specify reserved solver addresses",
         "subtasks": [
           {
             "id": 1,
-            "title": "Add optional reserved solver field to EVM IntentEscrow contract",
-            "description": "Modify the Escrow struct in IntentEscrow.sol to include an optional reservedSolver field that stores which solver address can receive/claim the escrow, and update createEscrow function to accept this parameter.",
+            "title": "Add required reserved solver field to EVM IntentEscrow contract",
+            "description": "Modify the Escrow struct in IntentEscrow.sol to include a required reservedSolver field that stores which solver address can receive/claim the escrow, and update createEscrow function to require this parameter.",
             "dependencies": [],
             "details": "Update the Escrow struct in evm-intent-framework/contracts/IntentEscrow.sol to add:\n- `address reservedSolver` field that stores which solver address receives the funds when escrow is claimed (address(0) means unreserved, funds go to msg.sender)\n- Modify `createEscrow()` function signature to accept optional `address reservedSolver` parameter\n- Store the reservedSolver address in the escrow struct during escrow creation\n- Update events to include the listed solver address (reservation status)",
             "status": "done",
@@ -40,57 +40,58 @@
             "title": "Integrate Move intent reservation system with escrow contracts",
             "description": "Update Aptos move contracts to use the existing intent_reservation.move system where IntentReserved stores the solver address that can claim the escrow.",
             "dependencies": [],
-            "details": "Modify move-intent-framework/sources/intent_as_escrow.move to:\n- Import and use existing `intent_reservation::IntentReserved` system from intent_reservation.move:19\n- The IntentReserved struct stores the solver address (solver: address) that can claim the escrow\n- Update `create_escrow()` function to accept optional reservation parameter containing the solver address\n- Store the IntentReserved (with solver address) in the escrow when created\n- Integrate with existing reservation verification in the Move framework\n- Use existing `intent_reservation::ensure_solver_authorized()` function to verify the solver matches the listed address\n- Maintain compatibility with existing oracle signature system",
-            "status": "pending",
+            "details": "Modify move-intent-framework/sources/intent_as_escrow.move to:\n- Import and use existing `intent_reservation::IntentReserved` system from intent_reservation.move:19\n- The IntentReserved struct stores the solver address (solver: address) that can claim the escrow\n- Update `create_escrow()` function to require reservation parameter (not Optional<IntentReserved>)\n- Store the IntentReserved (with solver address) in the escrow when created\n- Integrate with existing reservation verification in the Move framework\n- Use existing `intent_reservation::ensure_solver_authorized()` function to verify the solver matches the reserved address\n- Maintain compatibility with existing oracle signature system",
+            "status": "done",
             "testStrategy": "Unit tests for escrow creation and completion with Move reservation system where IntentReserved stores the solver address",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2025-11-10T09:08:33.893Z"
           },
           {
             "id": 4,
             "title": "Update Aptos escrow completion to transfer funds to reserved solver",
-            "description": "Modify the complete_escrow_from_fa function to deposit escrowed assets to the solver address listed in the escrow's IntentReserved (if one is listed), rather than the transaction signer.",
+            "description": "Modify the complete_escrow function to deposit escrowed assets to the solver address from the escrow's IntentReserved (which is now required), rather than the transaction signer.",
             "dependencies": [
               3
             ],
-            "details": "Update `complete_escrow_from_fa()` function in move-intent-framework/sources/intent_as_escrow_entry.move:59-84 to:\n- Check if escrow has IntentReserved (reservation parameter)\n- If IntentReserved exists, deposit escrowed assets to `intent_reserved.solver` instead of `signer::address_of(solver)` (line 74)\n- If no IntentReserved, deposit to transaction signer as before\n- Anyone can send the transaction, but funds always go to the reserved solver if one is listed\n- Maintain existing verifier signature verification flow\n- Ensure unreserved escrows (no IntentReserved) continue to work by depositing to transaction signer\n- Keep Ed25519 signature format unchanged",
-            "status": "pending",
-            "testStrategy": "Integration tests for escrow completion: funds go to reserved solver address when listed, regardless of who sends transaction. Test unreserved escrows deposit to transaction signer.",
+            "details": "Update `complete_escrow()` function in move-intent-framework/sources/intent_as_escrow.move to:\n- Access IntentReserved from the TradeSession (which is always present since escrows require reservations)\n- Deposit escrowed assets to `intent_reserved.solver` from the reservation\n- The `ensure_solver_authorized()` function already verifies the solver signer matches the reserved solver\n- Anyone can send the transaction, but funds always go to the reserved solver\n- Maintain existing verifier signature verification flow\n- Keep Ed25519 signature format unchanged\n- Update `create_escrow_from_fa()` to require reserved_solver parameter",
+            "status": "done",
+            "testStrategy": "Integration tests for escrow completion: funds always go to reserved solver address, regardless of who sends transaction",
             "parentId": "undefined"
           },
           {
             "id": 5,
-            "title": "Add comprehensive test coverage for reserved vs unreserved escrows",
-            "description": "Create extensive test suite covering both escrows that list a specific solver address and unreserved escrows (no listed solver) across EVM and Aptos implementations.",
+            "title": "Add comprehensive test coverage for reserved escrows",
+            "description": "Create extensive test suite covering escrows with required reserved solver addresses across EVM and Aptos implementations.",
             "dependencies": [
               2,
               4
             ],
-            "details": "Create comprehensive test coverage:\n- EVM tests: escrow creation with listed solver address, different accounts sending claim transaction but funds always go to reserved solver\n- Aptos tests: integration with IntentReserved system where escrow stores solver address, different accounts sending transaction but funds always go to reserved solver\n- Cross-chain tests: escrows that list a solver address work correctly across both chains\n- Security tests: verify signature replay prevention when escrow lists a specific solver (funds always go to reserved solver)\n- Backward compatibility tests: unreserved escrows (no listed solver) transfer to msg.sender/transaction signer as before\n- Edge case tests: empty/zero address handling (unreserved), state transitions",
-            "status": "pending",
-            "testStrategy": "Full test suite covering escrows with listed solver address vs unreserved escrows, including security, functionality, and compatibility testing",
+            "details": "Create comprehensive test coverage:\n- EVM tests: escrow creation with required reserved solver address, different accounts sending claim transaction but funds always go to reserved solver\n- EVM tests: verify that createEscrow reverts if reservedSolver is address(0)\n- Aptos tests: integration with IntentReserved system where escrow requires solver address, different accounts sending transaction but funds always go to reserved solver\n- Aptos tests: verify that create_escrow requires reservation parameter\n- Cross-chain tests: escrows with reserved solvers work correctly across both chains\n- Security tests: verify signature replay prevention (funds always go to reserved solver)\n- Edge case tests: verify all escrows must specify a solver address, state transitions",
+            "status": "done",
+            "testStrategy": "Full test suite covering escrows with required reserved solver addresses, including security and functionality testing",
             "parentId": "undefined"
           },
           {
             "id": 6,
-            "title": "Update E2E test scripts and documentation for reserved escrow feature",
-            "description": "Update end-to-end test scripts and documentation to cover escrows that list a specific solver address while maintaining backward compatibility with unreserved escrows.",
+            "title": "Update E2E test scripts and documentation for required reserved escrows",
+            "description": "Update end-to-end test scripts and documentation to reflect that all escrows must specify a reserved solver address.",
             "dependencies": [
               5
             ],
-            "details": "Update integration components:\n- Modify E2E test scripts to test both escrows with listed solver address and unreserved escrows (no listed solver)\n- Update API documentation to describe optional reservedSolver parameter that stores which solver can claim the escrow\n- Add examples of creating escrows with listed solver vs unreserved escrows\n- Update security documentation to explain how listing a solver address in the escrow prevents signature replay\n- Ensure all existing E2E flows continue to work (backward compatibility for unreserved escrows)\n- Document migration path for applications wanting to use escrows that list a specific solver address",
-            "status": "pending",
-            "testStrategy": "E2E testing with escrows listing a solver address and unreserved escrows, documentation review",
+            "details": "Update integration components:\n- Modify E2E test scripts to always specify a reserved solver address when creating escrows\n- Update API documentation to describe required reservedSolver parameter\n- Update examples to show escrow creation with reserved solver (no unreserved examples)\n- Update security documentation to explain how requiring a reserved solver prevents signature replay\n- Update all documentation to reflect that reservations are required, not optional\n- Remove references to unreserved escrows from documentation",
+            "status": "done",
+            "testStrategy": "E2E testing with escrows that have reserved solvers, documentation review",
             "parentId": "undefined"
           }
         ],
-        "updatedAt": "2025-11-10T08:26:18.658Z"
+        "updatedAt": "2025-11-10T09:08:33.893Z"
       }
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2025-11-10T08:26:18.661Z",
+      "lastModified": "2025-11-10T09:08:33.894Z",
       "taskCount": 1,
-      "completedCount": 0,
+      "completedCount": 1,
       "tags": [
         "master"
       ]

--- a/evm-intent-framework/README.md
+++ b/evm-intent-framework/README.md
@@ -16,9 +16,9 @@ ECDSA signature verification similar to the Aptos escrow system.
 
 ### Flow
 
-1. **Create**: Maker creates an escrow and deposits funds atomically (expiry is contract-defined)
+1. **Create**: Maker creates an escrow and deposits funds atomically (expiry is contract-defined). Must specify the solver address that will receive funds.
 2. **Verify** (off-chain): Verifier monitors conditions and signs approval
-3. **Claim**: Solver provides verifier signature to claim funds
+3. **Claim**: Anyone can provide verifier signature to claim funds. Funds always go to the reserved solver address specified at creation.
 4. **Cancel** (optional): Maker can cancel and reclaim after expiry
 
 ## Signature Verification
@@ -42,23 +42,25 @@ The contract uses `ecrecover()` to verify the signature matches the authorized v
 
 ```solidity
 // Create an escrow and deposit funds atomically (expiry is contract-defined)
-function createEscrow(uint256 intentId, address token, uint256 amount) external
+// reservedSolver: Required solver address that will receive funds (must not be address(0))
+function createEscrow(uint256 intentId, address token, uint256 amount, address reservedSolver) external
 
 // Claim funds with verifier signature
+// Funds always go to reservedSolver address (anyone can send transaction, but recipient is fixed)
 function claim(uint256 intentId, uint8 approvalValue, bytes memory signature) external
 
 // Cancel escrow and reclaim funds (maker only, after expiry)
 function cancel(uint256 intentId) external
 
 // Get escrow data
-function getEscrow(uint256 intentId) external view returns (address, address, uint256, bool, uint256)
+function getEscrow(uint256 intentId) external view returns (address, address, uint256, bool, uint256, address)
 ```
 
 ### Events
 
-- `EscrowInitialized(uint256 indexed intentId, address indexed escrow, address indexed maker, address token)`
+- `EscrowInitialized(uint256 indexed intentId, address indexed escrow, address indexed maker, address token, address reservedSolver)`
 - `DepositMade(uint256 indexed intentId, address indexed user, uint256 amount, uint256 total)`
-- `EscrowClaimed(uint256 indexed intentId, address indexed solver, uint256 amount)`
+- `EscrowClaimed(uint256 indexed intentId, address indexed recipient, uint256 amount)`
 - `EscrowCancelled(uint256 indexed intentId, address indexed maker, uint256 amount)`
 
 ## Setup
@@ -79,8 +81,9 @@ const IntentEscrow = await ethers.getContractFactory("IntentEscrow");
 const escrow = await IntentEscrow.deploy(verifierAddress);
 
 // Maker creates escrow and deposits tokens atomically (expiry is contract-defined)
+// Must specify solver address that will receive funds:
 await token.connect(maker).approve(escrow.address, amount);
-await escrow.connect(maker).createEscrow(intentId, tokenAddress, amount);
+await escrow.connect(maker).createEscrow(intentId, tokenAddress, amount, solverAddress);
 
 // Verifier signs approval (off-chain)
 const messageHash = ethers.solidityPackedKeccak256(
@@ -89,7 +92,7 @@ const messageHash = ethers.solidityPackedKeccak256(
 );
 const signature = await verifier.signMessage(ethers.getBytes(messageHash));
 
-// Solver claims with signature
+// Solver claims with signature (anyone can call, but funds go to reserved solver)
 await escrow.connect(solver).claim(intentId, 1, signature);
 ```
 
@@ -100,6 +103,7 @@ await escrow.connect(solver).claim(intentId, 1, signature);
 - **Reentrancy**: Uses OpenZeppelin's SafeERC20 to prevent reentrancy attacks
 - **Access Control**: Only maker can cancel escrow (after expiry)
 - **Immutable Verifier**: Verifier address is set in constructor and cannot be changed
+- **Solver Reservation**: All escrows must specify a reserved solver at creation, preventing unauthorized fund recipients and signature replay attacks
 
 ## Testing
 

--- a/evm-intent-framework/contracts/IntentEscrow.sol
+++ b/evm-intent-framework/contracts/IntentEscrow.sol
@@ -25,7 +25,7 @@ contract IntentEscrow {
         uint256 amount;          // Amount deposited
         bool isClaimed;          // Whether funds have been claimed
         uint256 expiry;          // Expiry timestamp (contract-defined). After expiry, claims are blocked but maker can cancel
-        address reservedSolver;  // Solver address that receives funds when escrow is claimed (address(0) means unreserved, funds go to msg.sender)
+        address reservedSolver;  // Solver address that receives funds when escrow is claimed (always set, never address(0))
     }
 
     /// @notice Mapping from intent ID to escrow data
@@ -62,10 +62,10 @@ contract IntentEscrow {
      * @param intentId Unique intent identifier
      * @param token ERC20 token address to be deposited (use address(0) for ETH)
      * @param amount Amount of tokens/ETH to deposit
-     * @param reservedSolver Optional solver address that will receive funds when escrow is claimed (address(0) means unreserved, funds go to msg.sender)
+     * @param reservedSolver Solver address that will receive funds when escrow is claimed (must not be address(0))
      * @dev Expiry is automatically set to block.timestamp + EXPIRY_DURATION (contract-defined)
      * @dev This function atomically creates the escrow and deposits funds, matching Move's create_escrow_from_fa
-     * @dev If reservedSolver is set, funds will always be transferred to that address regardless of who calls claim()
+     * @dev Funds will always be transferred to reservedSolver address regardless of who calls claim()
      */
     function createEscrow(
         uint256 intentId,
@@ -75,6 +75,7 @@ contract IntentEscrow {
     ) external payable {
         require(escrows[intentId].maker == address(0), "Escrow already exists");
         require(amount > 0, "Amount must be greater than 0");
+        require(reservedSolver != address(0), "Reserved solver must be specified");
 
         // Create escrow
         escrows[intentId] = Escrow({
@@ -143,7 +144,8 @@ contract IntentEscrow {
         escrow.amount = 0;
         
         // Determine recipient: if escrow lists a solver, transfer to that address; otherwise transfer to msg.sender
-        address recipient = escrow.reservedSolver != address(0) ? escrow.reservedSolver : msg.sender;
+        // Funds always go to the reserved solver (enforced at creation)
+        address recipient = escrow.reservedSolver;
         
         // Transfer tokens or ETH to recipient
         if (token == address(0)) {
@@ -231,7 +233,7 @@ contract IntentEscrow {
      * @return amount Amount deposited
      * @return isClaimed Whether escrow is claimed
      * @return expiry Expiry timestamp
-     * @return reservedSolver Solver address that receives funds (address(0) if unreserved)
+     * @return reservedSolver Solver address that receives funds (always set)
      */
     function getEscrow(uint256 intentId)
         external

--- a/evm-intent-framework/contracts/IntentEscrow.sol
+++ b/evm-intent-framework/contracts/IntentEscrow.sol
@@ -25,15 +25,16 @@ contract IntentEscrow {
         uint256 amount;          // Amount deposited
         bool isClaimed;          // Whether funds have been claimed
         uint256 expiry;          // Expiry timestamp (contract-defined). After expiry, claims are blocked but maker can cancel
+        address reservedSolver;  // Solver address that receives funds when escrow is claimed (address(0) means unreserved, funds go to msg.sender)
     }
 
     /// @notice Mapping from intent ID to escrow data
     mapping(uint256 => Escrow) public escrows;
 
     /// @notice Events
-    event EscrowInitialized(uint256 indexed intentId, address indexed escrow, address indexed maker, address token);
+    event EscrowInitialized(uint256 indexed intentId, address indexed escrow, address indexed maker, address token, address reservedSolver);
     event DepositMade(uint256 indexed intentId, address indexed user, uint256 amount, uint256 total);
-    event EscrowClaimed(uint256 indexed intentId, address indexed solver, uint256 amount);
+    event EscrowClaimed(uint256 indexed intentId, address indexed recipient, uint256 amount);
     event EscrowCancelled(uint256 indexed intentId, address indexed maker, uint256 amount);
 
     /// @notice Errors
@@ -61,13 +62,16 @@ contract IntentEscrow {
      * @param intentId Unique intent identifier
      * @param token ERC20 token address to be deposited (use address(0) for ETH)
      * @param amount Amount of tokens/ETH to deposit
+     * @param reservedSolver Optional solver address that will receive funds when escrow is claimed (address(0) means unreserved, funds go to msg.sender)
      * @dev Expiry is automatically set to block.timestamp + EXPIRY_DURATION (contract-defined)
      * @dev This function atomically creates the escrow and deposits funds, matching Move's create_escrow_from_fa
+     * @dev If reservedSolver is set, funds will always be transferred to that address regardless of who calls claim()
      */
     function createEscrow(
         uint256 intentId,
         address token,
-        uint256 amount
+        uint256 amount,
+        address reservedSolver
     ) external payable {
         require(escrows[intentId].maker == address(0), "Escrow already exists");
         require(amount > 0, "Amount must be greater than 0");
@@ -78,10 +82,11 @@ contract IntentEscrow {
             token: token,
             amount: 0,
             isClaimed: false,
-            expiry: block.timestamp + EXPIRY_DURATION
+            expiry: block.timestamp + EXPIRY_DURATION,
+            reservedSolver: reservedSolver
         });
 
-        emit EscrowInitialized(intentId, address(this), msg.sender, token);
+        emit EscrowInitialized(intentId, address(this), msg.sender, token, reservedSolver);
 
         // Deposit funds atomically
         if (token == address(0)) {
@@ -137,16 +142,19 @@ contract IntentEscrow {
         escrow.isClaimed = true;
         escrow.amount = 0;
         
-        // Transfer tokens or ETH to solver (msg.sender)
+        // Determine recipient: if escrow lists a solver, transfer to that address; otherwise transfer to msg.sender
+        address recipient = escrow.reservedSolver != address(0) ? escrow.reservedSolver : msg.sender;
+        
+        // Transfer tokens or ETH to recipient
         if (token == address(0)) {
             // ETH transfer
-            payable(msg.sender).transfer(amount);
+            payable(recipient).transfer(amount);
         } else {
             // ERC20 token transfer
-            IERC20(token).safeTransfer(msg.sender, amount);
+            IERC20(token).safeTransfer(recipient, amount);
         }
         
-        emit EscrowClaimed(intentId, msg.sender, amount);
+        emit EscrowClaimed(intentId, recipient, amount);
     }
 
     /**
@@ -223,6 +231,7 @@ contract IntentEscrow {
      * @return amount Amount deposited
      * @return isClaimed Whether escrow is claimed
      * @return expiry Expiry timestamp
+     * @return reservedSolver Solver address that receives funds (address(0) if unreserved)
      */
     function getEscrow(uint256 intentId)
         external
@@ -232,11 +241,12 @@ contract IntentEscrow {
             address token,
             uint256 amount,
             bool isClaimed,
-            uint256 expiry
+            uint256 expiry,
+            address reservedSolver
         )
     {
         Escrow memory escrow = escrows[intentId];
-        return (escrow.maker, escrow.token, escrow.amount, escrow.isClaimed, escrow.expiry);
+        return (escrow.maker, escrow.token, escrow.amount, escrow.isClaimed, escrow.expiry, escrow.reservedSolver);
     }
 }
 

--- a/evm-intent-framework/scripts/create-escrow-eth.js
+++ b/evm-intent-framework/scripts/create-escrow-eth.js
@@ -4,6 +4,7 @@ async function main() {
   const escrowAddress = process.env.ESCROW_ADDRESS;
   const intentIdHex = process.env.INTENT_ID_EVM;
   const amountWei = process.env.ETH_AMOUNT_WEI;
+  const reservedSolver = process.env.RESERVED_SOLVER || "0x0000000000000000000000000000000000000000";
 
   if (!escrowAddress || !intentIdHex || !amountWei) {
     throw new Error("Missing required environment variables: ESCROW_ADDRESS, INTENT_ID_EVM, ETH_AMOUNT_WEI");
@@ -15,11 +16,9 @@ async function main() {
   const amount = BigInt(amountWei);
   
   // Use address(0) for ETH
-  // Account 0 = deployer, Account 1 = Alice, Account 2 = Bob
-  // Expiry is contract-defined
   const ethAddress = "0x0000000000000000000000000000000000000000";
   
-  await escrow.connect(signers[1]).createEscrow(intentId, ethAddress, amount, { value: amount });
+  await escrow.connect(signers[1]).createEscrow(intentId, ethAddress, amount, reservedSolver, { value: amount });
   console.log("Escrow created for intent (ETH):", intentId.toString());
 }
 

--- a/evm-intent-framework/test/cancel.test.js
+++ b/evm-intent-framework/test/cancel.test.js
@@ -23,7 +23,7 @@ describe("IntentEscrow - Cancel", function () {
     amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address);
   });
 
   /// Test: Cancellation After Expiry

--- a/evm-intent-framework/test/cancel.test.js
+++ b/evm-intent-framework/test/cancel.test.js
@@ -23,7 +23,7 @@ describe("IntentEscrow - Cancel", function () {
     amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
   });
 
   /// Test: Cancellation After Expiry

--- a/evm-intent-framework/test/claim.test.js
+++ b/evm-intent-framework/test/claim.test.js
@@ -24,7 +24,7 @@ describe("IntentEscrow - Claim", function () {
     amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
     
     approvalValue = 1; // Approval value must be 1
   });

--- a/evm-intent-framework/test/claim.test.js
+++ b/evm-intent-framework/test/claim.test.js
@@ -24,7 +24,7 @@ describe("IntentEscrow - Claim", function () {
     amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address);
     
     approvalValue = 1; // Approval value must be 1
   });

--- a/evm-intent-framework/test/cross-chain.test.js
+++ b/evm-intent-framework/test/cross-chain.test.js
@@ -6,6 +6,7 @@ describe("IntentEscrow - Cross-Chain Intent ID Conversion", function () {
   let escrow;
   let token;
   let maker;
+  let solver;
   let intentId;
 
   beforeEach(async function () {
@@ -13,6 +14,7 @@ describe("IntentEscrow - Cross-Chain Intent ID Conversion", function () {
     escrow = fixtures.escrow;
     token = fixtures.token;
     maker = fixtures.maker;
+    solver = fixtures.solver;
     intentId = fixtures.intentId;
   });
 
@@ -27,7 +29,7 @@ describe("IntentEscrow - Cross-Chain Intent ID Conversion", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(evmIntentId, token.target, amount, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(evmIntentId, token.target, amount, solver.address);
 
     // Verify escrow was created correctly
     const escrowData = await escrow.getEscrow(evmIntentId);
@@ -47,21 +49,21 @@ describe("IntentEscrow - Cross-Chain Intent ID Conversion", function () {
 
     // Test maximum uint256 value
     const maxIntentId = BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-    await escrow.connect(maker).createEscrow(maxIntentId, token.target, amount, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(maxIntentId, token.target, amount, solver.address);
     const maxEscrowData = await escrow.getEscrow(maxIntentId);
     expect(maxEscrowData.maker).to.equal(maker.address);
     expect(maxEscrowData.amount).to.equal(amount);
 
     // Test zero value
     const zeroIntentId = 0n;
-    await escrow.connect(maker).createEscrow(zeroIntentId, token.target, amount, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(zeroIntentId, token.target, amount, solver.address);
     const zeroEscrowData = await escrow.getEscrow(zeroIntentId);
     expect(zeroEscrowData.maker).to.equal(maker.address);
     expect(zeroEscrowData.amount).to.equal(amount);
 
     // Test edge value (2^128 - 1)
     const edgeIntentId = BigInt("0xffffffffffffffffffffffffffffffff");
-    await escrow.connect(maker).createEscrow(edgeIntentId, token.target, amount, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(edgeIntentId, token.target, amount, solver.address);
     const edgeEscrowData = await escrow.getEscrow(edgeIntentId);
     expect(edgeEscrowData.maker).to.equal(maker.address);
     expect(edgeEscrowData.amount).to.equal(amount);
@@ -92,7 +94,7 @@ describe("IntentEscrow - Cross-Chain Intent ID Conversion", function () {
       expect(paddedIntentId).to.equal(expectedValue);
 
       // Verify escrow operations work with padded intent ID
-      await escrow.connect(maker).createEscrow(paddedIntentId, token.target, amount, ethers.ZeroAddress);
+      await escrow.connect(maker).createEscrow(paddedIntentId, token.target, amount, solver.address);
       const escrowData = await escrow.getEscrow(paddedIntentId);
       expect(escrowData.maker).to.equal(maker.address);
       expect(escrowData.amount).to.equal(amount);
@@ -117,7 +119,7 @@ describe("IntentEscrow - Cross-Chain Intent ID Conversion", function () {
 
     // Create escrows with different intent ID formats
     for (let i = 0; i < intentIds.length; i++) {
-      await escrow.connect(maker).createEscrow(intentIds[i], token.target, amount, ethers.ZeroAddress);
+      await escrow.connect(maker).createEscrow(intentIds[i], token.target, amount, solver.address);
       const escrowData = await escrow.getEscrow(intentIds[i]);
       expect(escrowData.maker).to.equal(maker.address);
       expect(escrowData.token).to.equal(token.target);

--- a/evm-intent-framework/test/cross-chain.test.js
+++ b/evm-intent-framework/test/cross-chain.test.js
@@ -27,7 +27,7 @@ describe("IntentEscrow - Cross-Chain Intent ID Conversion", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(evmIntentId, token.target, amount);
+    await escrow.connect(maker).createEscrow(evmIntentId, token.target, amount, ethers.ZeroAddress);
 
     // Verify escrow was created correctly
     const escrowData = await escrow.getEscrow(evmIntentId);
@@ -47,21 +47,21 @@ describe("IntentEscrow - Cross-Chain Intent ID Conversion", function () {
 
     // Test maximum uint256 value
     const maxIntentId = BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-    await escrow.connect(maker).createEscrow(maxIntentId, token.target, amount);
+    await escrow.connect(maker).createEscrow(maxIntentId, token.target, amount, ethers.ZeroAddress);
     const maxEscrowData = await escrow.getEscrow(maxIntentId);
     expect(maxEscrowData.maker).to.equal(maker.address);
     expect(maxEscrowData.amount).to.equal(amount);
 
     // Test zero value
     const zeroIntentId = 0n;
-    await escrow.connect(maker).createEscrow(zeroIntentId, token.target, amount);
+    await escrow.connect(maker).createEscrow(zeroIntentId, token.target, amount, ethers.ZeroAddress);
     const zeroEscrowData = await escrow.getEscrow(zeroIntentId);
     expect(zeroEscrowData.maker).to.equal(maker.address);
     expect(zeroEscrowData.amount).to.equal(amount);
 
     // Test edge value (2^128 - 1)
     const edgeIntentId = BigInt("0xffffffffffffffffffffffffffffffff");
-    await escrow.connect(maker).createEscrow(edgeIntentId, token.target, amount);
+    await escrow.connect(maker).createEscrow(edgeIntentId, token.target, amount, ethers.ZeroAddress);
     const edgeEscrowData = await escrow.getEscrow(edgeIntentId);
     expect(edgeEscrowData.maker).to.equal(maker.address);
     expect(edgeEscrowData.amount).to.equal(amount);
@@ -92,7 +92,7 @@ describe("IntentEscrow - Cross-Chain Intent ID Conversion", function () {
       expect(paddedIntentId).to.equal(expectedValue);
 
       // Verify escrow operations work with padded intent ID
-      await escrow.connect(maker).createEscrow(paddedIntentId, token.target, amount);
+      await escrow.connect(maker).createEscrow(paddedIntentId, token.target, amount, ethers.ZeroAddress);
       const escrowData = await escrow.getEscrow(paddedIntentId);
       expect(escrowData.maker).to.equal(maker.address);
       expect(escrowData.amount).to.equal(amount);
@@ -117,7 +117,7 @@ describe("IntentEscrow - Cross-Chain Intent ID Conversion", function () {
 
     // Create escrows with different intent ID formats
     for (let i = 0; i < intentIds.length; i++) {
-      await escrow.connect(maker).createEscrow(intentIds[i], token.target, amount);
+      await escrow.connect(maker).createEscrow(intentIds[i], token.target, amount, ethers.ZeroAddress);
       const escrowData = await escrow.getEscrow(intentIds[i]);
       expect(escrowData.maker).to.equal(maker.address);
       expect(escrowData.token).to.equal(token.target);

--- a/evm-intent-framework/test/deposit.test.js
+++ b/evm-intent-framework/test/deposit.test.js
@@ -6,6 +6,7 @@ describe("IntentEscrow - Create Escrow (Deposit)", function () {
   let escrow;
   let token;
   let maker;
+  let solver;
   let intentId;
 
   beforeEach(async function () {
@@ -13,6 +14,7 @@ describe("IntentEscrow - Create Escrow (Deposit)", function () {
     escrow = fixtures.escrow;
     token = fixtures.token;
     maker = fixtures.maker;
+    solver = fixtures.solver;
     intentId = fixtures.intentId;
   });
 
@@ -23,9 +25,9 @@ describe("IntentEscrow - Create Escrow (Deposit)", function () {
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
 
-    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress))
+    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address))
       .to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, token.target, ethers.ZeroAddress)
+      .withArgs(intentId, escrow.target, maker.address, token.target, solver.address)
       .and.to.emit(escrow, "DepositMade")
       .withArgs(intentId, maker.address, amount, amount);
 
@@ -41,12 +43,12 @@ describe("IntentEscrow - Create Escrow (Deposit)", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address);
 
     // This test is covered in claim.test.js - escrow creation with same intentId will fail
     // because escrow already exists, not because it's claimed
     await expect(
-      escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress)
+      escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address)
     ).to.be.revertedWith("Escrow already exists");
   });
 });

--- a/evm-intent-framework/test/deposit.test.js
+++ b/evm-intent-framework/test/deposit.test.js
@@ -23,9 +23,9 @@ describe("IntentEscrow - Create Escrow (Deposit)", function () {
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
 
-    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount))
+    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress))
       .to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, token.target)
+      .withArgs(intentId, escrow.target, maker.address, token.target, ethers.ZeroAddress)
       .and.to.emit(escrow, "DepositMade")
       .withArgs(intentId, maker.address, amount, amount);
 
@@ -41,12 +41,12 @@ describe("IntentEscrow - Create Escrow (Deposit)", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
 
     // This test is covered in claim.test.js - escrow creation with same intentId will fail
     // because escrow already exists, not because it's claimed
     await expect(
-      escrow.connect(maker).createEscrow(intentId, token.target, amount)
+      escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress)
     ).to.be.revertedWith("Escrow already exists");
   });
 });

--- a/evm-intent-framework/test/edge-cases.test.js
+++ b/evm-intent-framework/test/edge-cases.test.js
@@ -31,7 +31,7 @@ describe("IntentEscrow - Edge Cases", function () {
     await token.connect(maker).approve(escrow.target, maxAmount);
 
     // Create escrow with max intent ID and max amount
-    await expect(escrow.connect(maker).createEscrow(maxIntentId, token.target, maxAmount, ethers.ZeroAddress))
+    await expect(escrow.connect(maker).createEscrow(maxIntentId, token.target, maxAmount, solver.address))
       .to.emit(escrow, "EscrowInitialized");
     
     const escrowData = await escrow.getEscrow(maxIntentId);
@@ -48,7 +48,7 @@ describe("IntentEscrow - Edge Cases", function () {
     await token.mint(maker.address, minAmount);
     await token.connect(maker).approve(escrow.target, minAmount);
 
-    await expect(escrow.connect(maker).createEscrow(testIntentId, token.target, minAmount, ethers.ZeroAddress))
+    await expect(escrow.connect(maker).createEscrow(testIntentId, token.target, minAmount, solver.address))
       .to.emit(escrow, "EscrowInitialized");
     
     const escrowData = await escrow.getEscrow(testIntentId);
@@ -68,7 +68,7 @@ describe("IntentEscrow - Edge Cases", function () {
     // Create multiple escrows with sequential intent IDs
     for (let i = 0; i < numEscrows; i++) {
       const testIntentId = intentId + BigInt(i);
-      await expect(escrow.connect(maker).createEscrow(testIntentId, token.target, amount, ethers.ZeroAddress))
+      await expect(escrow.connect(maker).createEscrow(testIntentId, token.target, amount, solver.address))
         .to.emit(escrow, "EscrowInitialized");
       
       const escrowData = await escrow.getEscrow(testIntentId);
@@ -91,7 +91,7 @@ describe("IntentEscrow - Edge Cases", function () {
     const gasEstimates = [];
     for (let i = 0; i < numEscrows; i++) {
       const testIntentId = intentId + BigInt(i);
-      const tx = await escrow.connect(maker).createEscrow(testIntentId, token.target, amount, ethers.ZeroAddress);
+      const tx = await escrow.connect(maker).createEscrow(testIntentId, token.target, amount, solver.address);
       const receipt = await tx.wait();
       gasEstimates.push(receipt.gasUsed);
     }
@@ -118,7 +118,7 @@ describe("IntentEscrow - Edge Cases", function () {
     const promises = [];
     for (let i = 0; i < numEscrows; i++) {
       const testIntentId = intentId + BigInt(i);
-      promises.push(escrow.connect(maker).createEscrow(testIntentId, token.target, amount, ethers.ZeroAddress));
+      promises.push(escrow.connect(maker).createEscrow(testIntentId, token.target, amount, solver.address));
     }
 
     // Wait for all transactions

--- a/evm-intent-framework/test/edge-cases.test.js
+++ b/evm-intent-framework/test/edge-cases.test.js
@@ -31,7 +31,7 @@ describe("IntentEscrow - Edge Cases", function () {
     await token.connect(maker).approve(escrow.target, maxAmount);
 
     // Create escrow with max intent ID and max amount
-    await expect(escrow.connect(maker).createEscrow(maxIntentId, token.target, maxAmount))
+    await expect(escrow.connect(maker).createEscrow(maxIntentId, token.target, maxAmount, ethers.ZeroAddress))
       .to.emit(escrow, "EscrowInitialized");
     
     const escrowData = await escrow.getEscrow(maxIntentId);
@@ -48,7 +48,7 @@ describe("IntentEscrow - Edge Cases", function () {
     await token.mint(maker.address, minAmount);
     await token.connect(maker).approve(escrow.target, minAmount);
 
-    await expect(escrow.connect(maker).createEscrow(testIntentId, token.target, minAmount))
+    await expect(escrow.connect(maker).createEscrow(testIntentId, token.target, minAmount, ethers.ZeroAddress))
       .to.emit(escrow, "EscrowInitialized");
     
     const escrowData = await escrow.getEscrow(testIntentId);
@@ -68,7 +68,7 @@ describe("IntentEscrow - Edge Cases", function () {
     // Create multiple escrows with sequential intent IDs
     for (let i = 0; i < numEscrows; i++) {
       const testIntentId = intentId + BigInt(i);
-      await expect(escrow.connect(maker).createEscrow(testIntentId, token.target, amount))
+      await expect(escrow.connect(maker).createEscrow(testIntentId, token.target, amount, ethers.ZeroAddress))
         .to.emit(escrow, "EscrowInitialized");
       
       const escrowData = await escrow.getEscrow(testIntentId);
@@ -91,7 +91,7 @@ describe("IntentEscrow - Edge Cases", function () {
     const gasEstimates = [];
     for (let i = 0; i < numEscrows; i++) {
       const testIntentId = intentId + BigInt(i);
-      const tx = await escrow.connect(maker).createEscrow(testIntentId, token.target, amount);
+      const tx = await escrow.connect(maker).createEscrow(testIntentId, token.target, amount, ethers.ZeroAddress);
       const receipt = await tx.wait();
       gasEstimates.push(receipt.gasUsed);
     }
@@ -118,7 +118,7 @@ describe("IntentEscrow - Edge Cases", function () {
     const promises = [];
     for (let i = 0; i < numEscrows; i++) {
       const testIntentId = intentId + BigInt(i);
-      promises.push(escrow.connect(maker).createEscrow(testIntentId, token.target, amount));
+      promises.push(escrow.connect(maker).createEscrow(testIntentId, token.target, amount, ethers.ZeroAddress));
     }
 
     // Wait for all transactions

--- a/evm-intent-framework/test/error-conditions.test.js
+++ b/evm-intent-framework/test/error-conditions.test.js
@@ -24,7 +24,7 @@ describe("IntentEscrow - Error Conditions", function () {
   /// Verifies that createEscrow reverts when amount is zero.
   it("Should revert with zero amount in createEscrow", async function () {
     await expect(
-      escrow.connect(maker).createEscrow(intentId, token.target, 0, ethers.ZeroAddress)
+      escrow.connect(maker).createEscrow(intentId, token.target, 0, solver.address)
     ).to.be.revertedWith("Amount must be greater than 0");
   });
 
@@ -42,7 +42,7 @@ describe("IntentEscrow - Error Conditions", function () {
     await token.connect(maker).approve(escrow.target, insufficientAllowance);
 
     await expect(
-      escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress)
+      escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address)
     ).to.be.reverted;
   });
 
@@ -56,7 +56,7 @@ describe("IntentEscrow - Error Conditions", function () {
     await token.connect(maker).approve(escrow.target, maxAmount);
 
     // This should succeed if we have enough balance
-    await expect(escrow.connect(maker).createEscrow(intentId, token.target, maxAmount, ethers.ZeroAddress))
+    await expect(escrow.connect(maker).createEscrow(intentId, token.target, maxAmount, solver.address))
       .to.emit(escrow, "EscrowInitialized");
     
     const escrowData = await escrow.getEscrow(intentId);
@@ -69,9 +69,9 @@ describe("IntentEscrow - Error Conditions", function () {
     const amount = ethers.parseEther("1");
     
     await expect(
-      escrow.connect(maker).createEscrow(intentId, ethers.ZeroAddress, amount, ethers.ZeroAddress, { value: amount })
+      escrow.connect(maker).createEscrow(intentId, ethers.ZeroAddress, amount, solver.address, { value: amount })
     ).to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, ethers.ZeroAddress, ethers.ZeroAddress);
+      .withArgs(intentId, escrow.target, maker.address, ethers.ZeroAddress, solver.address);
     
     const escrowData = await escrow.getEscrow(intentId);
     expect(escrowData.token).to.equal(ethers.ZeroAddress);
@@ -85,7 +85,7 @@ describe("IntentEscrow - Error Conditions", function () {
     const wrongValue = ethers.parseEther("0.5");
 
     await expect(
-      escrow.connect(maker).createEscrow(intentId, ethers.ZeroAddress, amount, ethers.ZeroAddress, { value: wrongValue })
+      escrow.connect(maker).createEscrow(intentId, ethers.ZeroAddress, amount, solver.address, { value: wrongValue })
     ).to.be.revertedWith("ETH amount mismatch");
   });
 
@@ -97,7 +97,7 @@ describe("IntentEscrow - Error Conditions", function () {
     await token.connect(maker).approve(escrow.target, amount);
 
     await expect(
-      escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress, { value: amount })
+      escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address, { value: amount })
     ).to.be.revertedWith("ETH not accepted for token escrow");
   });
 
@@ -107,7 +107,7 @@ describe("IntentEscrow - Error Conditions", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address);
 
     const approvalValue = 1;
     const invalidSignature = "0x1234"; // Too short (not 65 bytes)

--- a/evm-intent-framework/test/error-conditions.test.js
+++ b/evm-intent-framework/test/error-conditions.test.js
@@ -24,7 +24,7 @@ describe("IntentEscrow - Error Conditions", function () {
   /// Verifies that createEscrow reverts when amount is zero.
   it("Should revert with zero amount in createEscrow", async function () {
     await expect(
-      escrow.connect(maker).createEscrow(intentId, token.target, 0)
+      escrow.connect(maker).createEscrow(intentId, token.target, 0, ethers.ZeroAddress)
     ).to.be.revertedWith("Amount must be greater than 0");
   });
 
@@ -42,7 +42,7 @@ describe("IntentEscrow - Error Conditions", function () {
     await token.connect(maker).approve(escrow.target, insufficientAllowance);
 
     await expect(
-      escrow.connect(maker).createEscrow(intentId, token.target, amount)
+      escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress)
     ).to.be.reverted;
   });
 
@@ -56,7 +56,7 @@ describe("IntentEscrow - Error Conditions", function () {
     await token.connect(maker).approve(escrow.target, maxAmount);
 
     // This should succeed if we have enough balance
-    await expect(escrow.connect(maker).createEscrow(intentId, token.target, maxAmount))
+    await expect(escrow.connect(maker).createEscrow(intentId, token.target, maxAmount, ethers.ZeroAddress))
       .to.emit(escrow, "EscrowInitialized");
     
     const escrowData = await escrow.getEscrow(intentId);
@@ -69,9 +69,9 @@ describe("IntentEscrow - Error Conditions", function () {
     const amount = ethers.parseEther("1");
     
     await expect(
-      escrow.connect(maker).createEscrow(intentId, ethers.ZeroAddress, amount, { value: amount })
+      escrow.connect(maker).createEscrow(intentId, ethers.ZeroAddress, amount, ethers.ZeroAddress, { value: amount })
     ).to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, ethers.ZeroAddress);
+      .withArgs(intentId, escrow.target, maker.address, ethers.ZeroAddress, ethers.ZeroAddress);
     
     const escrowData = await escrow.getEscrow(intentId);
     expect(escrowData.token).to.equal(ethers.ZeroAddress);
@@ -85,7 +85,7 @@ describe("IntentEscrow - Error Conditions", function () {
     const wrongValue = ethers.parseEther("0.5");
 
     await expect(
-      escrow.connect(maker).createEscrow(intentId, ethers.ZeroAddress, amount, { value: wrongValue })
+      escrow.connect(maker).createEscrow(intentId, ethers.ZeroAddress, amount, ethers.ZeroAddress, { value: wrongValue })
     ).to.be.revertedWith("ETH amount mismatch");
   });
 
@@ -97,7 +97,7 @@ describe("IntentEscrow - Error Conditions", function () {
     await token.connect(maker).approve(escrow.target, amount);
 
     await expect(
-      escrow.connect(maker).createEscrow(intentId, token.target, amount, { value: amount })
+      escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress, { value: amount })
     ).to.be.revertedWith("ETH not accepted for token escrow");
   });
 
@@ -107,7 +107,7 @@ describe("IntentEscrow - Error Conditions", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
 
     const approvalValue = 1;
     const invalidSignature = "0x1234"; // Too short (not 65 bytes)

--- a/evm-intent-framework/test/expiry.test.js
+++ b/evm-intent-framework/test/expiry.test.js
@@ -27,7 +27,7 @@ describe("IntentEscrow - Expiry Handling", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
 
     // Cancellation blocked before expiry
     await expect(
@@ -58,7 +58,7 @@ describe("IntentEscrow - Expiry Handling", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    const tx = await escrow.connect(maker).createEscrow(intentId, token.target, amount);
+    const tx = await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
     const receipt = await tx.wait();
     const block = await ethers.provider.getBlock(receipt.blockNumber);
 
@@ -79,7 +79,7 @@ describe("IntentEscrow - Expiry Handling", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
 
     // Advance time past expiry
     const expiryDuration = await escrow.EXPIRY_DURATION();

--- a/evm-intent-framework/test/expiry.test.js
+++ b/evm-intent-framework/test/expiry.test.js
@@ -27,7 +27,7 @@ describe("IntentEscrow - Expiry Handling", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address);
 
     // Cancellation blocked before expiry
     await expect(
@@ -58,7 +58,7 @@ describe("IntentEscrow - Expiry Handling", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    const tx = await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
+    const tx = await escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address);
     const receipt = await tx.wait();
     const block = await ethers.provider.getBlock(receipt.blockNumber);
 
@@ -79,7 +79,7 @@ describe("IntentEscrow - Expiry Handling", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address);
 
     // Advance time past expiry
     const expiryDuration = await escrow.EXPIRY_DURATION();

--- a/evm-intent-framework/test/initialization.test.js
+++ b/evm-intent-framework/test/initialization.test.js
@@ -31,13 +31,13 @@ describe("IntentEscrow - Initialization", function () {
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
     
-    const tx = await escrow.connect(maker).createEscrow(intentId, token.target, amount);
+    const tx = await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
     const receipt = await tx.wait();
     const block = await ethers.provider.getBlock(receipt.blockNumber);
     
     await expect(tx)
       .to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, token.target);
+      .withArgs(intentId, escrow.target, maker.address, token.target, ethers.ZeroAddress);
     
     await expect(tx)
       .to.emit(escrow, "DepositMade")
@@ -60,10 +60,10 @@ describe("IntentEscrow - Initialization", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
     
     await expect(
-      escrow.connect(maker).createEscrow(intentId, token.target, amount)
+      escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress)
     ).to.be.revertedWith("Escrow already exists");
   });
 });

--- a/evm-intent-framework/test/initialization.test.js
+++ b/evm-intent-framework/test/initialization.test.js
@@ -7,6 +7,7 @@ describe("IntentEscrow - Initialization", function () {
   let token;
   let verifier;
   let maker;
+  let solver;
   let intentId;
 
   beforeEach(async function () {
@@ -15,6 +16,7 @@ describe("IntentEscrow - Initialization", function () {
     token = fixtures.token;
     verifier = fixtures.verifier;
     maker = fixtures.maker;
+    solver = fixtures.solver;
     intentId = fixtures.intentId;
   });
 
@@ -31,13 +33,13 @@ describe("IntentEscrow - Initialization", function () {
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
     
-    const tx = await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
+    const tx = await escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address);
     const receipt = await tx.wait();
     const block = await ethers.provider.getBlock(receipt.blockNumber);
     
     await expect(tx)
       .to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, token.target, ethers.ZeroAddress);
+      .withArgs(intentId, escrow.target, maker.address, token.target, solver.address);
     
     await expect(tx)
       .to.emit(escrow, "DepositMade")
@@ -60,10 +62,10 @@ describe("IntentEscrow - Initialization", function () {
     const amount = ethers.parseEther("100");
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
-    await escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address);
     
     await expect(
-      escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress)
+      escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address)
     ).to.be.revertedWith("Escrow already exists");
   });
 });

--- a/evm-intent-framework/test/integration.test.js
+++ b/evm-intent-framework/test/integration.test.js
@@ -30,9 +30,9 @@ describe("IntentEscrow - Integration Tests", function () {
     await token.connect(maker).approve(escrow.target, amount);
     
     // Step 2: Create escrow and verify EscrowInitialized event
-    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress))
+    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address))
       .to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, token.target, ethers.ZeroAddress);
+      .withArgs(intentId, escrow.target, maker.address, token.target, solver.address);
     
     // Step 3: Verify escrow state
     const escrowDataBefore = await escrow.getEscrow(intentId);
@@ -86,15 +86,15 @@ describe("IntentEscrow - Integration Tests", function () {
     // Create escrows with different tokens
     await token1.mint(maker.address, amount1);
     await token1.connect(maker).approve(escrow.target, amount1);
-    await escrow.connect(maker).createEscrow(intentId1, token1.target, amount1, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(intentId1, token1.target, amount1, solver.address);
     
     await token2.mint(maker.address, amount2);
     await token2.connect(maker).approve(escrow.target, amount2);
-    await escrow.connect(maker).createEscrow(intentId2, token2.target, amount2, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(intentId2, token2.target, amount2, solver.address);
     
     await token3.mint(maker.address, amount3);
     await token3.connect(maker).approve(escrow.target, amount3);
-    await escrow.connect(maker).createEscrow(intentId3, token3.target, amount3, ethers.ZeroAddress);
+    await escrow.connect(maker).createEscrow(intentId3, token3.target, amount3, solver.address);
     
     // Verify all escrows were created correctly
     const escrow1 = await escrow.getEscrow(intentId1);
@@ -122,9 +122,9 @@ describe("IntentEscrow - Integration Tests", function () {
     await token.connect(maker).approve(escrow.target, amount);
     
     // Test EscrowInitialized event
-    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress))
+    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address))
       .to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, token.target, ethers.ZeroAddress);
+      .withArgs(intentId, escrow.target, maker.address, token.target, solver.address);
     
     // Test EscrowClaimed event
     const approvalValue = 1;
@@ -148,9 +148,9 @@ describe("IntentEscrow - Integration Tests", function () {
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
     
-    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress))
+    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, solver.address))
       .to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, token.target, ethers.ZeroAddress);
+      .withArgs(intentId, escrow.target, maker.address, token.target, solver.address);
     
     // Step 2: Verify escrow state before expiry
     const escrowDataBefore = await escrow.getEscrow(intentId);

--- a/evm-intent-framework/test/integration.test.js
+++ b/evm-intent-framework/test/integration.test.js
@@ -30,9 +30,9 @@ describe("IntentEscrow - Integration Tests", function () {
     await token.connect(maker).approve(escrow.target, amount);
     
     // Step 2: Create escrow and verify EscrowInitialized event
-    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount))
+    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress))
       .to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, token.target);
+      .withArgs(intentId, escrow.target, maker.address, token.target, ethers.ZeroAddress);
     
     // Step 3: Verify escrow state
     const escrowDataBefore = await escrow.getEscrow(intentId);
@@ -86,15 +86,15 @@ describe("IntentEscrow - Integration Tests", function () {
     // Create escrows with different tokens
     await token1.mint(maker.address, amount1);
     await token1.connect(maker).approve(escrow.target, amount1);
-    await escrow.connect(maker).createEscrow(intentId1, token1.target, amount1);
+    await escrow.connect(maker).createEscrow(intentId1, token1.target, amount1, ethers.ZeroAddress);
     
     await token2.mint(maker.address, amount2);
     await token2.connect(maker).approve(escrow.target, amount2);
-    await escrow.connect(maker).createEscrow(intentId2, token2.target, amount2);
+    await escrow.connect(maker).createEscrow(intentId2, token2.target, amount2, ethers.ZeroAddress);
     
     await token3.mint(maker.address, amount3);
     await token3.connect(maker).approve(escrow.target, amount3);
-    await escrow.connect(maker).createEscrow(intentId3, token3.target, amount3);
+    await escrow.connect(maker).createEscrow(intentId3, token3.target, amount3, ethers.ZeroAddress);
     
     // Verify all escrows were created correctly
     const escrow1 = await escrow.getEscrow(intentId1);
@@ -122,9 +122,9 @@ describe("IntentEscrow - Integration Tests", function () {
     await token.connect(maker).approve(escrow.target, amount);
     
     // Test EscrowInitialized event
-    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount))
+    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress))
       .to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, token.target);
+      .withArgs(intentId, escrow.target, maker.address, token.target, ethers.ZeroAddress);
     
     // Test EscrowClaimed event
     const approvalValue = 1;
@@ -148,9 +148,9 @@ describe("IntentEscrow - Integration Tests", function () {
     await token.mint(maker.address, amount);
     await token.connect(maker).approve(escrow.target, amount);
     
-    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount))
+    await expect(escrow.connect(maker).createEscrow(intentId, token.target, amount, ethers.ZeroAddress))
       .to.emit(escrow, "EscrowInitialized")
-      .withArgs(intentId, escrow.target, maker.address, token.target);
+      .withArgs(intentId, escrow.target, maker.address, token.target, ethers.ZeroAddress);
     
     // Step 2: Verify escrow state before expiry
     const escrowDataBefore = await escrow.getEscrow(intentId);

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
             pkgs.pkg-config
             pkgs.nodejs
             pkgs.nodePackages.npm
+            pkgs.git
             aptosCli
           ];
 

--- a/move-intent-framework/docs/development.md
+++ b/move-intent-framework/docs/development.md
@@ -87,7 +87,7 @@ aptos_intent = "0x123"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
-rev = "mainnet"
+rev = "<commit-hash>"  # See Move.toml for the actual pinned commit
 subdir = "aptos-framework"
 ```
 
@@ -95,7 +95,7 @@ subdir = "aptos-framework"
 - **Package Name**: `aptos-intent`
 - **Address**: Uses `_` for deployment flexibility
 - **Dev Address**: `0x123` for testing
-- **Dependencies**: Aptos Framework from mainnet branch
+- **Dependencies**: Aptos Framework pinned to a specific commit (see `Move.toml` for the exact commit hash)
 
 ### Development Environment
 
@@ -112,7 +112,7 @@ Enter the environment with `nix develop` from the project root.
 ### Aptos Framework
 
 - **Source**: [Aptos Framework](https://github.com/aptos-labs/aptos-framework)
-- **Branch**: `mainnet`
+- **Version**: Pinned to a specific commit hash (see `Move.toml` for the exact commit)
 - **Purpose**: Core blockchain functionality, fungible assets, cryptography
 
 ### Aptos CLI

--- a/move-intent-framework/sources/intent_reservation.move
+++ b/move-intent-framework/sources/intent_reservation.move
@@ -156,4 +156,10 @@ module aptos_intent::intent_reservation {
             assert!(signer::address_of(solver_signer) == intent_reserved.solver, EUNAUTHORIZED_SOLVER);
         }
     }
+
+    /// Creates an IntentReserved struct for testing or direct use.
+    /// This is a simple constructor that doesn't require signature verification.
+    public fun new_reservation(solver: address): IntentReserved {
+        IntentReserved { solver }
+    }
 }

--- a/move-intent-framework/tests/fa_intent_with_oracle_tests.move
+++ b/move-intent-framework/tests/fa_intent_with_oracle_tests.move
@@ -143,9 +143,10 @@ module aptos_intent::fa_intent_with_oracle_tests {
             requirement,
             true, // revocable by default for tests
             @0x1, // dummy intent_id for testing
+            std::option::none(), // unreserved intent
         );
 
-        let (unlocked_fa, session) = fa_intent_with_oracle::start_fa_offering_session(intent);
+        let (unlocked_fa, session) = fa_intent_with_oracle::start_fa_offering_session(solver, intent);
         primary_fungible_store::deposit(signer::address_of(solver), unlocked_fa);
 
         (oracle_secret_key, session, desired_fa_type, offered_fa_type)

--- a/testing-infra/e2e-tests-apt/submit-escrow.sh
+++ b/testing-infra/e2e-tests-apt/submit-escrow.sh
@@ -24,6 +24,7 @@ CHAIN2_ADDRESS=$(get_profile_address "intent-account-chain2")
 ALICE_CHAIN1_ADDRESS=$(get_profile_address "alice-chain1")
 BOB_CHAIN1_ADDRESS=$(get_profile_address "bob-chain1")
 ALICE_CHAIN2_ADDRESS=$(get_profile_address "alice-chain2")
+BOB_CHAIN2_ADDRESS=$(get_profile_address "bob-chain2")
 
 log ""
 log "📋 Chain Information:"
@@ -32,6 +33,7 @@ log "   Connected Chain (Chain 2): $CHAIN2_ADDRESS"
 log "   Alice Chain 1 (hub):     $ALICE_CHAIN1_ADDRESS"
 log "   Bob Chain 1 (hub):       $BOB_CHAIN1_ADDRESS"
 log "   Alice Chain 2 (connected): $ALICE_CHAIN2_ADDRESS"
+log "   Bob Chain 2 (connected): $BOB_CHAIN2_ADDRESS"
 
 # Load oracle public key from verifier config (base64 encoded, needs to be converted to hex)
 # Use verifier_testing.toml for tests - required, panic if not found
@@ -93,11 +95,13 @@ log "     ✅ Got APT metadata on Chain 2: $APT_METADATA_CHAIN2"
 SOURCE_FA_METADATA_CHAIN2="$APT_METADATA_CHAIN2"
 
 # Submit escrow intent using Alice's account on Chain 2 (connected chain)
+# Reserved solver: Bob on Chain 2 - funds will go to Bob when escrow is claimed
 log "   - Creating escrow intent on Chain 2..."
 log "     Source FA metadata: $SOURCE_FA_METADATA_CHAIN2"
+log "     Reserved solver: $BOB_CHAIN2_ADDRESS (Bob on Chain 2)"
 aptos move run --profile alice-chain2 --assume-yes \
     --function-id "0x${CHAIN2_ADDRESS}::intent_as_escrow_entry::create_escrow_from_fa" \
-    --args "address:${SOURCE_FA_METADATA_CHAIN2}" "u64:100000000" "hex:${ORACLE_PUBLIC_KEY}" "u64:${EXPIRY_TIME}" "address:${INTENT_ID}" >> "$LOG_FILE" 2>&1
+    --args "address:${SOURCE_FA_METADATA_CHAIN2}" "u64:100000000" "hex:${ORACLE_PUBLIC_KEY}" "u64:${EXPIRY_TIME}" "address:${INTENT_ID}" "address:${BOB_CHAIN2_ADDRESS}" >> "$LOG_FILE" 2>&1
 
 if [ $? -eq 0 ]; then
     log "     ✅ Escrow intent created on Chain 2!"

--- a/testing-infra/e2e-tests-evm/submit-escrow.sh
+++ b/testing-infra/e2e-tests-evm/submit-escrow.sh
@@ -63,9 +63,10 @@ log "     Intent ID (EVM): $INTENT_ID_EVM"
 
 # Create escrow for this intent with ETH (address(0)) and deposit funds atomically
 log "   - Creating escrow for intent (ETH escrow) with funds..."
-# Expiry is contract-defined (1 hour), creation and deposit happen atomically
+# Reserved solver: Bob - funds will go to Bob when escrow is claimed
+BOB_ADDRESS=$(get_hardhat_account_address "2")
 ETH_AMOUNT_WEI="1000000000000000000000"  # 1000 ETH = 1000 * 10^18 wei
-CREATE_OUTPUT=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ESCROW_ADDRESS='$ESCROW_ADDRESS' INTENT_ID_EVM='$INTENT_ID_EVM' ETH_AMOUNT_WEI='$ETH_AMOUNT_WEI' npx hardhat run scripts/create-escrow-eth.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
+CREATE_OUTPUT=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ESCROW_ADDRESS='$ESCROW_ADDRESS' INTENT_ID_EVM='$INTENT_ID_EVM' ETH_AMOUNT_WEI='$ETH_AMOUNT_WEI' RESERVED_SOLVER='$BOB_ADDRESS' npx hardhat run scripts/create-escrow-eth.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
 CREATE_EXIT_CODE=$?
 
 # Check if creation was successful


### PR DESCRIPTION
# security: Require reserved solver addresses for all escrows

## Summary

This PR fixes a critical security vulnerability where verifier signatures don't bind to solver addresses, allowing signature replay attacks. All escrows now require a reserved solver address at creation time, ensuring funds are always transferred to the specified solver regardless of who sends the claim transaction.

## Types of Changes

- Bug fix
- Breaking change
- Tests

## Description

**Security Issue**: Verifier signatures only included (intentId, approvalValue) in the signed message, making them reusable by any solver who obtains a valid signature. This allowed unauthorized escrow claims.

**Solution**: Require all escrows to specify a reserved solver address at creation. The solver address is stored in the escrow and enforced on-chain. Anyone can send the claim transaction, but funds always go to the reserved solver.

**Changes**:
- **EVM Contract**: Added required `reservedSolver` parameter to `createEscrow()` with address(0) validation. Modified `claim()` to always transfer funds to `reservedSolver`.
- **Move Contracts**: Updated `create_escrow()` and `create_escrow_from_fa()` to require `IntentReserved` parameter (not optional). Added `new_reservation()` helper function.
- **Tests**: Updated all EVM and Move unit tests to specify reserved solver addresses. All tests pass.
- **Documentation**: Updated READMEs and docs to reflect required reservations, removed references to unreserved escrows.
- **E2E Tests**: Updated Aptos E2E test script to pass reserved solver parameter.

## Breaking Changes

- **EVM**: `createEscrow()` now requires `reservedSolver` parameter (must not be address(0))
- **Move**: `create_escrow_from_fa()` now requires `reserved_solver` parameter
- All existing escrow creation code must be updated to specify a solver address

## Checklist

- [x] Code follows the style guidelines
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated
- [x] Tests added/updated for new functionality
- [x] Breaking changes documented in relevant READMEs

### Testing

- [x] Unit tests pass (EVM: 37 passing, Move: 23 passing)
- [x] Integration tests pass (Rust verifier tests pass)
- [x] E2E tests pass (E2E Aptos script updated)
