### PR TITLE
refact: change USDxyz to USDhub or USDcon

### DIFF
--- a/.taskmaster/docs/conception/conception_generic.md
+++ b/.taskmaster/docs/conception/conception_generic.md
@@ -25,7 +25,7 @@ The framework can also function as an escrow mechanism, allowing funds to be loc
 
 ## Actors
 
-- Requester: the requester that wants to swap some USDxyz from one chain to another using the intent process. One of the chains is always M1 chain.
+- Requester: the requester that wants to swap some USDhub/USDcon from one chain to another using the intent process.
 - Solver: actor that solves the swap intent. Can be anyone in a permissionless setting.
 - Movement (Mvmt): Represents the Movement corporation that operates the intent application. Depending on the protocol but it can be a trusted entity if it runs some part of the protocol like the verifier.
 - Adversary: a malicious actor that wants to steal some funds or disturb the system.
@@ -148,7 +148,7 @@ Only one solver can fulfill an intent, even if multiple solvers attempt simultan
 ### Stolen funds risk
 
 - the escrow account can be hacked.
-- the final transfer contract that sends the intent USDxyz amount to the initial chain can be hacked and do false transfers.
+- the final transfer step can be hacked and do false transfers.
 
 ### Disturb the service
 

--- a/.taskmaster/docs/conception/conception_inflow.md
+++ b/.taskmaster/docs/conception/conception_inflow.md
@@ -8,7 +8,7 @@ For general use cases applicable to all flows, see [conception_generic.md](conce
 
 ### Users (Requester)
 
-- As a requester, I want to swap some USDxyz from a connected chain to M1 chain so that I get my USDxyz on M1 chain fast and with low fee.
+- As a requester, I want to swap some USDcon from a connected chain to M1 chain so that I get my USDhub on M1 chain fast and with low fee.
 
 ## Protocol
 
@@ -53,7 +53,7 @@ sequenceDiagram
 ### Requester makes an inflow swap intent
 
 0. Given the requester
-   - owns the USDxyz that they want to transfer
+   - owns the USDcon that they want to transfer
    - owns some MOVE to execute Tx on M1 chain
    - owns offered tokens on connected chain
    - can access the connected chain and M1 chain RPC
@@ -61,15 +61,15 @@ sequenceDiagram
 1. When the requester wants to realize a swap from connected chain to M1 chain
    - then the requester requests a signed quote from a solver for the desired intent
    - then the requester sends a request-intent Tx to the M1 chain. ( 2) Requester initiates intent protocol step)
-   - then the requester sends a Tx to connected chain to transfer the needed USDxyz + total fees token to an escrow. ( 1) Requester deposit protocol step)
+   - then the requester sends a Tx to connected chain to transfer the needed USDcon + total fees token to an escrow. ( 1) Requester deposit protocol step)
    - then the requester waits for a confirmation of the swap
-   - then the requester has received the requested amount of USDxyz in their M1 chain account.
+   - then the requester has received the requested amount of USDhub in their M1 chain account.
 
 #### Possible issues (Requester)
 
 1. The requester initial escrow transfer is too little or too much.
     - _Mitigation: The verifier verifies that the escrow transfer amount is the same as the request-intent offered amount._
-1. The requester didn't get the right expected amount of USDxyz.
+1. The requester didn't get the right expected amount of USDhub.
     - _Mitigation: The verifier verifies that the escrow transfer amount is the same as the request-intent amount._
 1. The escrow deposit on the connected chain fails. How can the requester withdraw their tokens?
     - _Mitigation: The escrow eventually times out and the requester can withdraw their tokens._
@@ -78,14 +78,14 @@ sequenceDiagram
 
 #### Questions
 
-- Are the fees in USDxyz or in the chain token?
+- Are the fees in USDcon or in the chain token?
 
 ### Solver resolves an inflow swap intent
 
 0. Given the solver
    - is registered in the solver registry on Hub chain
    - owns some MOVE to execute Tx on M1 chain
-   - owns enough USDxyz on M1 chain
+   - owns enough USDhub on M1 chain
    - can access both chains' RPC
 1. When the requester creates a draft intent and sends it to the solver
    - Then the solver signs the draft intent off-chain and returns signature
@@ -116,9 +116,9 @@ sequenceDiagram
 0. Given the adversary takes the requester role to do a swap
 1. When the adversary wants to extract more funds than the adversary has provided
    - Then the adversary sends a request-intent Tx to the M1 chain.
-   - Then the adversary sends a Tx to the connected chain that transfers too little USDxyz token to an escrow.
-   - Then the adversary hopes to get more USDxyz on the M1 chain than they have provided.
-      - _Mitigation: The solver verifies that the correct offered amount (USDxyz requested amount + fee) has been transferred to the escrow._
+   - Then the adversary sends a Tx to the connected chain that transfers too little USDcon token to an escrow.
+   - Then the adversary hopes to get more USDhub on the M1 chain than they have provided.
+      - _Mitigation: The solver verifies that the correct offered amount (USDcon requested amount + fee) has been transferred to the escrow._
       - _Mitigation: The verifier verifies that the escrow transfer amount is the same as the request-intent offered amount._
 2. When the adversary attempts to stall the request-intent holding solver funds hostage.
    - Then the adversary reserves the intent

--- a/.taskmaster/docs/conception/conception_outflow.md
+++ b/.taskmaster/docs/conception/conception_outflow.md
@@ -8,7 +8,7 @@ For general use cases applicable to all flows, see [conception_generic.md](conce
 
 ### Users (Requester)
 
-- As a requester, I want to swap some USDxyz from M1 chain to a connected chain so that I get my USDxyz on the connected chain fast and with low fee.
+- As a requester, I want to swap some USDhub from M1 chain to a connected chain so that I get my USDcon on the connected chain fast and with low fee.
 
 ## Protocol
 
@@ -48,18 +48,18 @@ sequenceDiagram
 ### Requester makes an outflow swap intent
 
 0. Given the requester
-   - owns the USDxyz that they want to transfer on M1 chain
+   - owns the USDhub that they want to transfer on M1 chain
    - owns some MOVE to execute Tx on M1 chain
    - can access the connected chain and M1 chain RPC
 1. When the requester wants to realize a swap from M1 chain to connected chain
    - then the requester requests a signed quote from a solver for the desired intent
    - then the requester sends a request-intent Tx to the M1 chain with escrow (locks tokens on Hub)
    - then the requester waits for a confirmation of the swap
-   - then the requester has received the requested amount of USDxyz in their connected chain account.
+   - then the requester has received the requested amount of USDcon in their connected chain account.
 
 #### Possible issues (Requester)
 
-1. The requester didn't get the right expected amount of USDxyz on connected chain.
+1. The requester didn't get the right expected amount of USDcon on connected chain.
     - _Mitigation: The verifier verifies that the transfer amount on connected chain matches the request-intent desired amount. Only if the amount is correct, the verifier signs the approval for escrow release._
 2. The solver never fulfills on connected chain. How can the requester withdraw their tokens?
     - _Mitigation: The escrow on Hub eventually times out and the requester can withdraw their tokens._
@@ -69,7 +69,7 @@ sequenceDiagram
 0. Given the solver
    - is registered in the solver registry on Hub chain
    - owns some MOVE to execute Tx on M1 chain
-   - owns enough USDxyz on the connected chain
+   - owns enough USDcon on the connected chain
    - can access both chains' RPC
 1. When the requester creates a draft intent and sends it to the solver
    - Then the solver signs the draft intent off-chain and returns signature
@@ -99,7 +99,7 @@ sequenceDiagram
 0. Given the adversary takes the requester role to do a swap
 1. When the adversary wants to extract more funds than the adversary has provided
    - Then the adversary sends a request-intent Tx to the M1 chain with less tokens in escrow than declared.
-   - Then the adversary hopes to get more USDxyz on the connected chain than they have provided.
+   - Then the adversary hopes to get more USDcon on the connected chain than they have provided on the hub.
    - _Mitigation: The escrow amount is locked at request-intent creation. The contract enforces the offered amount._
 2. When the adversary attempts to stall the request-intent holding solver funds hostage.
    - Then the adversary creates the intent

--- a/.taskmaster/docs/conception/conception_routerflow.md
+++ b/.taskmaster/docs/conception/conception_routerflow.md
@@ -8,7 +8,7 @@ For general use cases applicable to all flows, see [conception_generic.md](conce
 
 ### Users (Requester)
 
-- As a requester, I want to swap some USDxyz from one connected chain to another connected chain so that I get my USDxyz on the destination chain fast and with low fee.
+- As a requester, I want to swap some USDcon from one connected chain to another connected chain so that I get my USDcon on the destination chain fast and with low fee.
 
 ## Protocol
 
@@ -56,22 +56,22 @@ sequenceDiagram
 ### Requester makes a router-flow swap intent
 
 0. Given the requester
-   - owns the USDxyz that they want to transfer on source connected chain
+   - owns the USDcon that they want to transfer on source connected chain
    - owns some MOVE to execute Tx on M1 chain
    - can access both connected chains and M1 chain RPC
 
 1. When the requester wants to realize a swap from source connected chain to destination connected chain
    - then the requester requests a signed quote from a solver for the intent
    - then the requester sends a request-intent Tx to the M1 chain
-   - then the requester sends a Tx to source connected chain to transfer the needed USDxyz + total fees to an escrow
+   - then the requester sends a Tx to source connected chain to transfer the needed USDcon + total fees to an escrow
    - then the requester waits for a confirmation of the swap
-   - then the requester has received the requested amount of USDxyz in their destination connected chain account.
+   - then the requester has received the requested amount of USDcon in their destination connected chain account.
 
 #### Possible issues (Requester)
 
 1. The requester initial escrow transfer is too little or too much.
     - _Mitigation: The solver verifies that the escrow transfer amount is the same as the request-intent offered amount before transferring the funds on the destination connected chain. Alternatively, the solver queries the verifier which verifies that the escrow transfer amount is the same as the request-intent offered amount and informs the solver._
-2. The requester didn't get the right expected amount of USDxyz on the destination connected chain.
+2. The requester didn't get the right expected amount of USDcon on the destination connected chain.
     - _Mitigation: The verifier verifies that the transfer amount on the destination connected chain matches the request-intent desired amount. Only if the amount is correct, the verifier signs the approval for escrow release._
 3. The escrow deposit on the source connected chain fails. How can the requester withdraw their tokens?
     - _Mitigation: The escrow eventually times out and the requester can withdraw their tokens._
@@ -82,7 +82,7 @@ sequenceDiagram
 
 0. Given the solver
    - is registered in the solver registry on Hub chain
-   - owns enough USDxyz on the destination connected chain
+   - owns enough USDcon on the destination connected chain
    - can access all chains' RPC
 
 1. When the requester creates a draft intent and sends it to the solver
@@ -116,8 +116,8 @@ sequenceDiagram
 0. Given the adversary takes the requester role to do a swap
 1. When the adversary wants to extract more funds than the adversary has provided on the source connected chain
    - Then the adversary sends a request-intent Tx to the M1 chain.
-   - Then the adversary sends a Tx to the source connected chain that transfers too little USDxyz token to an escrow.
-   - Then the adversary hopes to get more USDxyz on the destination chain than they have provided.
+   - Then the adversary sends a Tx to the source connected chain that transfers too little USDcon token to an escrow.
+   - Then the adversary hopes to get more USDcon on the destination chain than they have provided.
       - _Mitigation: The solver verifies that the correct offered amount has been transferred to the escrow before fulfilling._
       - _Mitigation: The verifier verifies that the escrow transfer amount is the same as the request-intent offered amount and informs the solver._
 2. When the adversary attempts to stall the intent, holding solver funds hostage.

--- a/evm-intent-framework/test-scripts/deploy-usdcon.js
+++ b/evm-intent-framework/test-scripts/deploy-usdcon.js
@@ -7,7 +7,7 @@ const hre = require("hardhat");
 /// Deploys USDcon token
 ///
 /// Deploys a MockERC20 contract with name "USDcon" and symbol "USDcon".
-/// Uses 6 decimals (matching MVM USDxyz, like USDC/USDT).
+/// Uses 6 decimals (like USDC/USDT).
 ///
 /// # Returns
 /// Outputs token address on success.

--- a/evm-intent-framework/test-scripts/deploy-usdcon.js
+++ b/evm-intent-framework/test-scripts/deploy-usdcon.js
@@ -1,31 +1,31 @@
-//! USDxyz token deployment utility
+//! USDcon token deployment utility
 //!
-//! This script deploys a MockERC20 token as USDxyz for testing.
+//! This script deploys a MockERC20 token as USDcon for testing on connected EVM chains.
 
 const hre = require("hardhat");
 
-/// Deploys USDxyz token
+/// Deploys USDcon token
 ///
-/// Deploys a MockERC20 contract with name "USDxyz" and symbol "USDxyz".
+/// Deploys a MockERC20 contract with name "USDcon" and symbol "USDcon".
 /// Uses 6 decimals (matching MVM USDxyz, like USDC/USDT).
 ///
 /// # Returns
 /// Outputs token address on success.
 async function main() {
-  console.log("Deploying USDxyz token...");
+  console.log("Deploying USDcon token...");
 
   const [deployer] = await hre.ethers.getSigners();
   
   console.log("Deploying with account:", deployer.address);
 
-  // Deploy MockERC20 as USDxyz with 6 decimals (matching MVM, like USDC/USDT)
+  // Deploy MockERC20 as USDcon with 6 decimals (matching MVM, like USDC/USDT)
   const MockERC20 = await hre.ethers.getContractFactory("MockERC20");
-  const token = await MockERC20.deploy("USDxyz", "USDxyz", 6);
+  const token = await MockERC20.deploy("USDcon", "USDcon", 6);
 
   await token.waitForDeployment();
 
   const tokenAddress = await token.getAddress();
-  console.log("USDxyz deployed to:", tokenAddress);
+  console.log("USDcon deployed to:", tokenAddress);
 }
 
 main()

--- a/testing-infra/ci-e2e/chain-connected-evm/deploy-contract.sh
+++ b/testing-infra/ci-e2e/chain-connected-evm/deploy-contract.sh
@@ -78,7 +78,7 @@ log "✅ IntentEscrow deployed"
 log ""
 log "💵 Deploying USDcon token to EVM chain..."
 
-USDCON_OUTPUT=$(run_hardhat_command "npx hardhat run test-scripts/deploy-usdxyz.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
+USDCON_OUTPUT=$(run_hardhat_command "npx hardhat run test-scripts/deploy-usdcon.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
 # Extract token address from Hardhat output (line containing 'deployed to:')
 USDCON_TOKEN_ADDRESS=$(echo "$USDCON_OUTPUT" | grep "deployed to:" | awk '{print $NF}' | tr -d '\n')
 

--- a/testing-infra/ci-e2e/chain-connected-evm/deploy-contract.sh
+++ b/testing-infra/ci-e2e/chain-connected-evm/deploy-contract.sh
@@ -78,9 +78,9 @@ log "✅ IntentEscrow deployed"
 log ""
 log "💵 Deploying USDcon token to EVM chain..."
 
-USDXYZ_OUTPUT=$(run_hardhat_command "npx hardhat run test-scripts/deploy-usdxyz.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
+USDCON_OUTPUT=$(run_hardhat_command "npx hardhat run test-scripts/deploy-usdxyz.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
 # Extract token address from Hardhat output (line containing 'deployed to:')
-USDCON_TOKEN_ADDRESS=$(echo "$USDXYZ_OUTPUT" | grep "deployed to:" | awk '{print $NF}' | tr -d '\n')
+USDCON_TOKEN_ADDRESS=$(echo "$USDCON_OUTPUT" | grep "deployed to:" | awk '{print $NF}' | tr -d '\n')
 
 if [ -z "$USDCON_TOKEN_ADDRESS" ]; then
     log_and_echo "❌ USDcon deployment failed!"

--- a/testing-infra/ci-e2e/chain-connected-evm/deploy-contract.sh
+++ b/testing-infra/ci-e2e/chain-connected-evm/deploy-contract.sh
@@ -80,18 +80,18 @@ log "💵 Deploying USDcon token to EVM chain..."
 
 USDXYZ_OUTPUT=$(run_hardhat_command "npx hardhat run test-scripts/deploy-usdxyz.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
 # Extract token address from Hardhat output (line containing 'deployed to:')
-USDXYZ_ADDRESS=$(echo "$USDXYZ_OUTPUT" | grep "deployed to:" | awk '{print $NF}' | tr -d '\n')
+USDCON_TOKEN_ADDRESS=$(echo "$USDXYZ_OUTPUT" | grep "deployed to:" | awk '{print $NF}' | tr -d '\n')
 
-if [ -z "$USDXYZ_ADDRESS" ]; then
+if [ -z "$USDCON_TOKEN_ADDRESS" ]; then
     log_and_echo "❌ USDcon deployment failed!"
     exit 1
 fi
 
-log "   ✅ USDcon deployed to: $USDXYZ_ADDRESS"
+log "   ✅ USDcon deployed to: $USDCON_TOKEN_ADDRESS"
 
 # Save escrow and USDcon addresses for other scripts
 echo "ESCROW_CONTRACT_ADDRESS=$CONTRACT_ADDRESS" >> "$PROJECT_ROOT/.tmp/chain-info.env"
-echo "USDXYZ_EVM_ADDRESS=$USDXYZ_ADDRESS" >> "$PROJECT_ROOT/.tmp/chain-info.env"
+echo "USDCON_EVM_ADDRESS=$USDCON_TOKEN_ADDRESS" >> "$PROJECT_ROOT/.tmp/chain-info.env"
 
 # Mint USDcon to Requester and Solver (accounts 1 and 2)
 log ""
@@ -99,10 +99,10 @@ log "💵 Minting USDcon to Requester and Solver on EVM chain..."
 
 REQUESTER_EVM_ADDRESS=$(get_hardhat_account_address "1")
 SOLVER_EVM_ADDRESS=$(get_hardhat_account_address "2")
-USDXYZ_MINT_AMOUNT="1000000"  # 1 USDcon (6 decimals = 1_000_000)
+USDCON_MINT_AMOUNT="1000000"  # 1 USDcon (6 decimals = 1_000_000)
 
-log "   - Minting USDcon to Requester ($REQUESTER_EVM_ADDRESS)..."
-MINT_OUTPUT=$(run_hardhat_command "npx hardhat run scripts/mint-token.js --network localhost" "TOKEN_ADDRESS='$USDXYZ_ADDRESS' RECIPIENT='$REQUESTER_EVM_ADDRESS' AMOUNT='$USDXYZ_MINT_AMOUNT'" 2>&1 | tee -a "$LOG_FILE")
+log "   - Minting $USDCON_MINT_AMOUNT 10e-6.USDcon to Requester ($REQUESTER_EVM_ADDRESS)..."
+MINT_OUTPUT=$(run_hardhat_command "npx hardhat run scripts/mint-token.js --network localhost" "TOKEN_ADDRESS='$USDCON_TOKEN_ADDRESS' RECIPIENT='$REQUESTER_EVM_ADDRESS' AMOUNT='$USDCON_MINT_AMOUNT'" 2>&1 | tee -a "$LOG_FILE")
 if echo "$MINT_OUTPUT" | grep -q "SUCCESS"; then
     log "   ✅ Minted USDcon to Requester"
 else
@@ -110,8 +110,8 @@ else
     exit 1
 fi
 
-log "   - Minting USDcon to Solver ($SOLVER_EVM_ADDRESS)..."
-MINT_OUTPUT=$(run_hardhat_command "npx hardhat run scripts/mint-token.js --network localhost" "TOKEN_ADDRESS='$USDXYZ_ADDRESS' RECIPIENT='$SOLVER_EVM_ADDRESS' AMOUNT='$USDXYZ_MINT_AMOUNT'" 2>&1 | tee -a "$LOG_FILE")
+log "   - Minting $USDCON_MINT_AMOUNT 10e-6.USDcon to Solver ($SOLVER_EVM_ADDRESS)..."
+MINT_OUTPUT=$(run_hardhat_command "npx hardhat run scripts/mint-token.js --network localhost" "TOKEN_ADDRESS='$USDCON_TOKEN_ADDRESS' RECIPIENT='$SOLVER_EVM_ADDRESS' AMOUNT='$USDCON_MINT_AMOUNT'" 2>&1 | tee -a "$LOG_FILE")
 if echo "$MINT_OUTPUT" | grep -q "SUCCESS"; then
     log "   ✅ Minted USDcon to Solver"
 else
@@ -122,7 +122,7 @@ fi
 log_and_echo "✅ USDcon minted to Requester and Solver on EVM chain"
 
 # Display balances (ETH + USDcon)
-display_balances_connected_evm "$USDXYZ_ADDRESS"
+display_balances_connected_evm "$USDCON_TOKEN_ADDRESS"
 
 log ""
 log "🎉 EVM DEPLOYMENT COMPLETE!"
@@ -131,7 +131,7 @@ log "EVM Chain:"
 log "   RPC URL:  http://127.0.0.1:8545"
 log "   Chain ID: 31337"
 log "   IntentEscrow: $CONTRACT_ADDRESS"
-log "   USDcon Token: $USDXYZ_ADDRESS"
+log "   USDcon Token: $USDCON_TOKEN_ADDRESS"
 log "   Verifier: $VERIFIER_ETH_ADDRESS"
 log ""
 log "📡 API Examples:"

--- a/testing-infra/ci-e2e/chain-connected-evm/deploy-contract.sh
+++ b/testing-infra/ci-e2e/chain-connected-evm/deploy-contract.sh
@@ -74,53 +74,54 @@ log "   npx hardhat verify --network localhost $CONTRACT_ADDRESS <verifier_addre
 log ""
 log "✅ IntentEscrow deployed"
 
-# Deploy USDxyz token
+# Deploy USDcon token
 log ""
-log "💵 Deploying USDxyz token to EVM chain..."
+log "💵 Deploying USDcon token to EVM chain..."
 
 USDXYZ_OUTPUT=$(run_hardhat_command "npx hardhat run test-scripts/deploy-usdxyz.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
-USDXYZ_ADDRESS=$(echo "$USDXYZ_OUTPUT" | grep "USDxyz deployed to:" | awk '{print $NF}' | tr -d '\n')
+# Extract token address from Hardhat output (line containing 'deployed to:')
+USDXYZ_ADDRESS=$(echo "$USDXYZ_OUTPUT" | grep "deployed to:" | awk '{print $NF}' | tr -d '\n')
 
 if [ -z "$USDXYZ_ADDRESS" ]; then
-    log_and_echo "❌ USDxyz deployment failed!"
+    log_and_echo "❌ USDcon deployment failed!"
     exit 1
 fi
 
-log "   ✅ USDxyz deployed to: $USDXYZ_ADDRESS"
+log "   ✅ USDcon deployed to: $USDXYZ_ADDRESS"
 
-# Save escrow and USDxyz addresses for other scripts
+# Save escrow and USDcon addresses for other scripts
 echo "ESCROW_CONTRACT_ADDRESS=$CONTRACT_ADDRESS" >> "$PROJECT_ROOT/.tmp/chain-info.env"
 echo "USDXYZ_EVM_ADDRESS=$USDXYZ_ADDRESS" >> "$PROJECT_ROOT/.tmp/chain-info.env"
 
-# Mint USDxyz to Requester and Solver (accounts 1 and 2)
+# Mint USDcon to Requester and Solver (accounts 1 and 2)
 log ""
-log "💵 Minting USDxyz to Requester and Solver on EVM chain..."
+log "💵 Minting USDcon to Requester and Solver on EVM chain..."
 
 REQUESTER_EVM_ADDRESS=$(get_hardhat_account_address "1")
 SOLVER_EVM_ADDRESS=$(get_hardhat_account_address "2")
-USDXYZ_MINT_AMOUNT="1000000"  # 1 USDxyz (6 decimals = 1_000_000)
+USDXYZ_MINT_AMOUNT="1000000"  # 1 USDcon (6 decimals = 1_000_000)
 
-log "   - Minting USDxyz to Requester ($REQUESTER_EVM_ADDRESS)..."
+log "   - Minting USDcon to Requester ($REQUESTER_EVM_ADDRESS)..."
 MINT_OUTPUT=$(run_hardhat_command "npx hardhat run scripts/mint-token.js --network localhost" "TOKEN_ADDRESS='$USDXYZ_ADDRESS' RECIPIENT='$REQUESTER_EVM_ADDRESS' AMOUNT='$USDXYZ_MINT_AMOUNT'" 2>&1 | tee -a "$LOG_FILE")
 if echo "$MINT_OUTPUT" | grep -q "SUCCESS"; then
-    log "   ✅ Minted USDxyz to Requester"
+    log "   ✅ Minted USDcon to Requester"
 else
-    log_and_echo "   ❌ Failed to mint USDxyz to Requester"
+    log_and_echo "   ❌ Failed to mint USDcon to Requester"
     exit 1
 fi
 
-log "   - Minting USDxyz to Solver ($SOLVER_EVM_ADDRESS)..."
+log "   - Minting USDcon to Solver ($SOLVER_EVM_ADDRESS)..."
 MINT_OUTPUT=$(run_hardhat_command "npx hardhat run scripts/mint-token.js --network localhost" "TOKEN_ADDRESS='$USDXYZ_ADDRESS' RECIPIENT='$SOLVER_EVM_ADDRESS' AMOUNT='$USDXYZ_MINT_AMOUNT'" 2>&1 | tee -a "$LOG_FILE")
 if echo "$MINT_OUTPUT" | grep -q "SUCCESS"; then
-    log "   ✅ Minted USDxyz to Solver"
+    log "   ✅ Minted USDcon to Solver"
 else
-    log_and_echo "   ❌ Failed to mint USDxyz to Solver"
+    log_and_echo "   ❌ Failed to mint USDcon to Solver"
     exit 1
 fi
 
-log_and_echo "✅ USDxyz minted to Requester and Solver on EVM chain"
+log_and_echo "✅ USDcon minted to Requester and Solver on EVM chain"
 
-# Display balances (ETH + USDxyz)
+# Display balances (ETH + USDcon)
 display_balances_connected_evm "$USDXYZ_ADDRESS"
 
 log ""
@@ -130,7 +131,7 @@ log "EVM Chain:"
 log "   RPC URL:  http://127.0.0.1:8545"
 log "   Chain ID: 31337"
 log "   IntentEscrow: $CONTRACT_ADDRESS"
-log "   USDxyz Token: $USDXYZ_ADDRESS"
+log "   USDcon Token: $USDXYZ_ADDRESS"
 log "   Verifier: $VERIFIER_ETH_ADDRESS"
 log ""
 log "📡 API Examples:"

--- a/testing-infra/ci-e2e/chain-connected-mvm/deploy-contracts.sh
+++ b/testing-infra/ci-e2e/chain-connected-mvm/deploy-contracts.sh
@@ -66,69 +66,69 @@ log ""
 log "🔧 Initializing solver registry..."
 initialize_solver_registry "intent-account-chain2" "$CHAIN2_ADDRESS" "$LOG_FILE"
 
-# Deploy USDxyz test token
+# Deploy USDcon test token
 log ""
-log "💵 Deploying USDxyz test token to Chain 2..."
+log "💵 Deploying USDcon test token to Chain 2..."
 
 TEST_TOKENS_CHAIN2_ADDRESS=$(get_profile_address "test-tokens-chain2")
 
-log "   - Deploying USDxyz with address: $TEST_TOKENS_CHAIN2_ADDRESS"
+log "   - Deploying USDcon with address: $TEST_TOKENS_CHAIN2_ADDRESS"
 cd testing-infra/ci-e2e/test-tokens
 aptos move publish --profile test-tokens-chain2 --named-addresses test_tokens=$TEST_TOKENS_CHAIN2_ADDRESS --assume-yes >> "$LOG_FILE" 2>&1
 
 if [ $? -eq 0 ]; then
-    log "   ✅ USDxyz deployment successful on Chain 2!"
-    log_and_echo "✅ USDxyz test token deployed on connected chain"
+    log "   ✅ USDcon deployment successful on Chain 2!"
+    log_and_echo "✅ USDcon test token deployed on connected chain"
 else
-    log_and_echo "   ❌ USDxyz deployment failed on Chain 2!"
+    log_and_echo "   ❌ USDcon deployment failed on Chain 2!"
     exit 1
 fi
 
 cd "$PROJECT_ROOT"
 
-# Export USDxyz address for other scripts
+# Export USDcon address for other scripts
 echo "TEST_TOKENS_CHAIN2_ADDRESS=$TEST_TOKENS_CHAIN2_ADDRESS" >> "$PROJECT_ROOT/.tmp/chain-info.env"
-log "   ✅ USDxyz address saved: $TEST_TOKENS_CHAIN2_ADDRESS"
+log "   ✅ USDcon address saved: $TEST_TOKENS_CHAIN2_ADDRESS"
 
-# Mint USDxyz to Requester and Solver
+# Mint USDcon to Requester and Solver
 log ""
-log "💵 Minting USDxyz to Requester and Solver on Chain 2..."
+log "💵 Minting USDcon to Requester and Solver on Chain 2..."
 
 REQUESTER_CHAIN2_ADDRESS=$(get_profile_address "requester-chain2")
 SOLVER_CHAIN2_ADDRESS=$(get_profile_address "solver-chain2")
-USDXYZ_MINT_AMOUNT="1000000"  # 1 USDxyz (6 decimals = 1_000_000)
+USDXYZ_MINT_AMOUNT="1000000"  # 1 USDcon (6 decimals = 1_000_000)
 
-log "   - Minting $USDXYZ_MINT_AMOUNT USDxyz to Requester ($REQUESTER_CHAIN2_ADDRESS)..."
+log "   - Minting $USDXYZ_MINT_AMOUNT USDcon to Requester ($REQUESTER_CHAIN2_ADDRESS)..."
 aptos move run --profile test-tokens-chain2 --assume-yes \
     --function-id ${TEST_TOKENS_CHAIN2_ADDRESS}::usdxyz::mint \
     --args address:$REQUESTER_CHAIN2_ADDRESS u64:$USDXYZ_MINT_AMOUNT >> "$LOG_FILE" 2>&1
 
 if [ $? -eq 0 ]; then
-    log "   ✅ Minted USDxyz to Requester"
+    log "   ✅ Minted USDcon to Requester"
 else
-    log_and_echo "   ❌ Failed to mint USDxyz to Requester"
+    log_and_echo "   ❌ Failed to mint USDcon to Requester"
     exit 1
 fi
 
-log "   - Minting $USDXYZ_MINT_AMOUNT USDxyz to Solver ($SOLVER_CHAIN2_ADDRESS)..."
+log "   - Minting $USDXYZ_MINT_AMOUNT USDcon to Solver ($SOLVER_CHAIN2_ADDRESS)..."
 aptos move run --profile test-tokens-chain2 --assume-yes \
     --function-id ${TEST_TOKENS_CHAIN2_ADDRESS}::usdxyz::mint \
     --args address:$SOLVER_CHAIN2_ADDRESS u64:$USDXYZ_MINT_AMOUNT >> "$LOG_FILE" 2>&1
 
 if [ $? -eq 0 ]; then
-    log "   ✅ Minted USDxyz to Solver"
+    log "   ✅ Minted USDcon to Solver"
 else
-    log_and_echo "   ❌ Failed to mint USDxyz to Solver"
+    log_and_echo "   ❌ Failed to mint USDcon to Solver"
     exit 1
 fi
 
-log_and_echo "✅ USDxyz minted to Requester and Solver on connected chain (1 USDxyz each)"
+log_and_echo "✅ USDcon minted to Requester and Solver on connected chain (1 USDcon each)"
 
 # Assert balances are correct after minting
 assert_usdxyz_balance "requester-chain2" "2" "$TEST_TOKENS_CHAIN2_ADDRESS" "1000000" "post-mint-requester"
 assert_usdxyz_balance "solver-chain2" "2" "$TEST_TOKENS_CHAIN2_ADDRESS" "1000000" "post-mint-solver"
 
-# Display balances (APT + USDxyz)
+# Display balances (APT + USDcon)
 display_balances_connected_mvm "$TEST_TOKENS_CHAIN2_ADDRESS"
 
 log ""

--- a/testing-infra/ci-e2e/chain-connected-mvm/deploy-contracts.sh
+++ b/testing-infra/ci-e2e/chain-connected-mvm/deploy-contracts.sh
@@ -96,12 +96,12 @@ log "💵 Minting USDcon to Requester and Solver on Chain 2..."
 
 REQUESTER_CHAIN2_ADDRESS=$(get_profile_address "requester-chain2")
 SOLVER_CHAIN2_ADDRESS=$(get_profile_address "solver-chain2")
-USDXYZ_MINT_AMOUNT="1000000"  # 1 USDcon (6 decimals = 1_000_000)
+USDCON_MINT_AMOUNT="1000000"  # 1 USDcon (6 decimals = 1_000_000)
 
-log "   - Minting $USDXYZ_MINT_AMOUNT USDcon to Requester ($REQUESTER_CHAIN2_ADDRESS)..."
+log "   - Minting $USDCON_MINT_AMOUNT 10e-6.USDcon to Requester ($REQUESTER_CHAIN2_ADDRESS)..."
 aptos move run --profile test-tokens-chain2 --assume-yes \
     --function-id ${TEST_TOKENS_CHAIN2_ADDRESS}::usdxyz::mint \
-    --args address:$REQUESTER_CHAIN2_ADDRESS u64:$USDXYZ_MINT_AMOUNT >> "$LOG_FILE" 2>&1
+    --args address:$REQUESTER_CHAIN2_ADDRESS u64:$USDCON_MINT_AMOUNT >> "$LOG_FILE" 2>&1
 
 if [ $? -eq 0 ]; then
     log "   ✅ Minted USDcon to Requester"
@@ -110,10 +110,10 @@ else
     exit 1
 fi
 
-log "   - Minting $USDXYZ_MINT_AMOUNT USDcon to Solver ($SOLVER_CHAIN2_ADDRESS)..."
+log "   - Minting $USDCON_MINT_AMOUNT 10e-6.USDcon to Solver ($SOLVER_CHAIN2_ADDRESS)..."
 aptos move run --profile test-tokens-chain2 --assume-yes \
     --function-id ${TEST_TOKENS_CHAIN2_ADDRESS}::usdxyz::mint \
-    --args address:$SOLVER_CHAIN2_ADDRESS u64:$USDXYZ_MINT_AMOUNT >> "$LOG_FILE" 2>&1
+    --args address:$SOLVER_CHAIN2_ADDRESS u64:$USDCON_MINT_AMOUNT >> "$LOG_FILE" 2>&1
 
 if [ $? -eq 0 ]; then
     log "   ✅ Minted USDcon to Solver"

--- a/testing-infra/ci-e2e/chain-connected-mvm/setup-requester-solver.sh
+++ b/testing-infra/ci-e2e/chain-connected-mvm/setup-requester-solver.sh
@@ -41,7 +41,7 @@ init_aptos_profile "requester-chain2" "2" "$LOG_FILE"
 log "Creating solver-chain2 account for Chain 2..."
 init_aptos_profile "solver-chain2" "2" "$LOG_FILE"
 
-# Create test-tokens account for Chain 2 (for USDxyz deployment)
+# Create test-tokens account for Chain 2 (for USDcon deployment)
 log "Creating test-tokens-chain2 account for Chain 2..."
 init_aptos_profile "test-tokens-chain2" "2" "$LOG_FILE"
 

--- a/testing-infra/ci-e2e/chain-hub/deploy-contracts.sh
+++ b/testing-infra/ci-e2e/chain-hub/deploy-contracts.sh
@@ -96,12 +96,12 @@ log "💵 Minting USDhub to Requester and Solver on Chain 1..."
 
 REQUESTER_CHAIN1_ADDRESS=$(get_profile_address "requester-chain1")
 SOLVER_CHAIN1_ADDRESS=$(get_profile_address "solver-chain1")
-USDXYZ_MINT_AMOUNT="1000000"  # 1 USDhub (6 decimals = 1_000_000)
+USDHUB_MINT_AMOUNT="1000000"  # 1 USDhub (6 decimals = 1_000_000)
 
-log "   - Minting $USDXYZ_MINT_AMOUNT USDhub to Requester ($REQUESTER_CHAIN1_ADDRESS)..."
+log "   - Minting $USDHUB_MINT_AMOUNT 10e-6.USDhub to Requester ($REQUESTER_CHAIN1_ADDRESS)..."
 aptos move run --profile test-tokens-chain1 --assume-yes \
     --function-id ${TEST_TOKENS_CHAIN1_ADDRESS}::usdxyz::mint \
-    --args address:$REQUESTER_CHAIN1_ADDRESS u64:$USDXYZ_MINT_AMOUNT >> "$LOG_FILE" 2>&1
+    --args address:$REQUESTER_CHAIN1_ADDRESS u64:$USDHUB_MINT_AMOUNT >> "$LOG_FILE" 2>&1
 
 if [ $? -eq 0 ]; then
     log "   ✅ Minted USDhub to Requester"
@@ -110,10 +110,10 @@ else
     exit 1
 fi
 
-log "   - Minting $USDXYZ_MINT_AMOUNT USDhub to Solver ($SOLVER_CHAIN1_ADDRESS)..."
+log "   - Minting $USDHUB_MINT_AMOUNT 10e-6.USDhub to Solver ($SOLVER_CHAIN1_ADDRESS)..."
 aptos move run --profile test-tokens-chain1 --assume-yes \
     --function-id ${TEST_TOKENS_CHAIN1_ADDRESS}::usdxyz::mint \
-    --args address:$SOLVER_CHAIN1_ADDRESS u64:$USDXYZ_MINT_AMOUNT >> "$LOG_FILE" 2>&1
+    --args address:$SOLVER_CHAIN1_ADDRESS u64:$USDHUB_MINT_AMOUNT >> "$LOG_FILE" 2>&1
 
 if [ $? -eq 0 ]; then
     log "   ✅ Minted USDhub to Solver"

--- a/testing-infra/ci-e2e/chain-hub/deploy-contracts.sh
+++ b/testing-infra/ci-e2e/chain-hub/deploy-contracts.sh
@@ -66,65 +66,65 @@ log ""
 log "🔧 Initializing solver registry..."
 initialize_solver_registry "intent-account-chain1" "$CHAIN1_ADDRESS" "$LOG_FILE"
 
-# Deploy USDxyz test token
+# Deploy USDhub test token
 log ""
-log "💵 Deploying USDxyz test token to Chain 1..."
+log "💵 Deploying USDhub test token to Chain 1..."
 
 TEST_TOKENS_CHAIN1_ADDRESS=$(get_profile_address "test-tokens-chain1")
 
-log "   - Deploying USDxyz with address: $TEST_TOKENS_CHAIN1_ADDRESS"
+log "   - Deploying USDhub with address: $TEST_TOKENS_CHAIN1_ADDRESS"
 cd testing-infra/ci-e2e/test-tokens
 aptos move publish --profile test-tokens-chain1 --named-addresses test_tokens=$TEST_TOKENS_CHAIN1_ADDRESS --assume-yes >> "$LOG_FILE" 2>&1
 
 if [ $? -eq 0 ]; then
-    log "   ✅ USDxyz deployment successful on Chain 1!"
-    log_and_echo "✅ USDxyz test token deployed on hub chain"
+    log "   ✅ USDhub deployment successful on Chain 1!"
+    log_and_echo "✅ USDhub test token deployed on hub chain"
 else
-    log_and_echo "   ❌ USDxyz deployment failed on Chain 1!"
+    log_and_echo "   ❌ USDhub deployment failed on Chain 1!"
     exit 1
 fi
 
 cd "$PROJECT_ROOT"
 
-# Export USDxyz address for other scripts (cleanup deletes this file, so append is safe - creates file if it doesn't exist)
+# Export USDhub address for other scripts (cleanup deletes this file, so append is safe - creates file if it doesn't exist)
 echo "TEST_TOKENS_CHAIN1_ADDRESS=$TEST_TOKENS_CHAIN1_ADDRESS" >> "$PROJECT_ROOT/.tmp/chain-info.env"
-log "   ✅ USDxyz address saved: $TEST_TOKENS_CHAIN1_ADDRESS"
+log "   ✅ USDhub address saved: $TEST_TOKENS_CHAIN1_ADDRESS"
 
-# Mint USDxyz to Requester and Solver
+# Mint USDhub to Requester and Solver
 log ""
-log "💵 Minting USDxyz to Requester and Solver on Chain 1..."
+log "💵 Minting USDhub to Requester and Solver on Chain 1..."
 
 REQUESTER_CHAIN1_ADDRESS=$(get_profile_address "requester-chain1")
 SOLVER_CHAIN1_ADDRESS=$(get_profile_address "solver-chain1")
-USDXYZ_MINT_AMOUNT="1000000"  # 1 USDxyz (6 decimals = 1_000_000)
+USDXYZ_MINT_AMOUNT="1000000"  # 1 USDhub (6 decimals = 1_000_000)
 
-log "   - Minting $USDXYZ_MINT_AMOUNT USDxyz to Requester ($REQUESTER_CHAIN1_ADDRESS)..."
+log "   - Minting $USDXYZ_MINT_AMOUNT USDhub to Requester ($REQUESTER_CHAIN1_ADDRESS)..."
 aptos move run --profile test-tokens-chain1 --assume-yes \
     --function-id ${TEST_TOKENS_CHAIN1_ADDRESS}::usdxyz::mint \
     --args address:$REQUESTER_CHAIN1_ADDRESS u64:$USDXYZ_MINT_AMOUNT >> "$LOG_FILE" 2>&1
 
 if [ $? -eq 0 ]; then
-    log "   ✅ Minted USDxyz to Requester"
+    log "   ✅ Minted USDhub to Requester"
 else
-    log_and_echo "   ❌ Failed to mint USDxyz to Requester"
+    log_and_echo "   ❌ Failed to mint USDhub to Requester"
     exit 1
 fi
 
-log "   - Minting $USDXYZ_MINT_AMOUNT USDxyz to Solver ($SOLVER_CHAIN1_ADDRESS)..."
+log "   - Minting $USDXYZ_MINT_AMOUNT USDhub to Solver ($SOLVER_CHAIN1_ADDRESS)..."
 aptos move run --profile test-tokens-chain1 --assume-yes \
     --function-id ${TEST_TOKENS_CHAIN1_ADDRESS}::usdxyz::mint \
     --args address:$SOLVER_CHAIN1_ADDRESS u64:$USDXYZ_MINT_AMOUNT >> "$LOG_FILE" 2>&1
 
 if [ $? -eq 0 ]; then
-    log "   ✅ Minted USDxyz to Solver"
+    log "   ✅ Minted USDhub to Solver"
 else
-    log_and_echo "   ❌ Failed to mint USDxyz to Solver"
+    log_and_echo "   ❌ Failed to mint USDhub to Solver"
     exit 1
 fi
 
-log_and_echo "✅ USDxyz minted to Requester and Solver on hub chain (1 USDxyz each)"
+log_and_echo "✅ USDhub minted to Requester and Solver on hub chain (1 USDhub each)"
 
-# Display balances (APT + USDxyz)
+# Display balances (APT + USDhub)
 display_balances_hub "$TEST_TOKENS_CHAIN1_ADDRESS"
 
 log ""

--- a/testing-infra/ci-e2e/chain-hub/setup-requester-solver.sh
+++ b/testing-infra/ci-e2e/chain-hub/setup-requester-solver.sh
@@ -41,7 +41,7 @@ init_aptos_profile "requester-chain1" "1" "$LOG_FILE"
 log "Creating solver-chain1 account for Chain 1..."
 init_aptos_profile "solver-chain1" "1" "$LOG_FILE"
 
-# Create test-tokens account for Chain 1 (for USDxyz deployment)
+# Create test-tokens account for Chain 1 (for USDhub deployment)
 log "Creating test-tokens-chain1 account for Chain 1..."
 init_aptos_profile "test-tokens-chain1" "1" "$LOG_FILE"
 

--- a/testing-infra/ci-e2e/e2e-tests-evm/balance-check.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/balance-check.sh
@@ -4,7 +4,7 @@
 # Displays and validates final balances for Hub (Chain 1, USDhub) and Connected EVM (Chain 3, USDcon)
 # Usage: balance-check.sh <solver_chain_hub> <requester_chain_hub> <solver_chain_connected> <requester_chain_connected>
 #   - Pass -1 for any parameter to skip that check
-#   - Values are in 10e-6.USDxyz units (e.g., 2000000 = 2 USDxyz)
+#   - Values are in 10e-6.USDhub / 10e-6.USDcon units (e.g., 2000000 = 2 USDhub or 2 USDcon)
 
 # Source common utilities
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -24,7 +24,7 @@ REQUESTER_CHAIN_CONNECTED_EXPECTED="${4:-}"
 # Get test tokens addresses
 TEST_TOKENS_CHAIN1=$(get_profile_address "test-tokens-chain1" 2>/dev/null) || true
 source "$PROJECT_ROOT/.tmp/chain-info.env" 2>/dev/null || true
-USDXYZ_ADDRESS="$USDXYZ_EVM_ADDRESS"
+USDCON_TOKEN_ADDRESS="$USDCON_EVM_ADDRESS"
 
 # Display balances
 if [ -z "$TEST_TOKENS_CHAIN1" ]; then
@@ -34,11 +34,11 @@ else
     display_balances_hub "0x$TEST_TOKENS_CHAIN1"
 fi
 
-if [ -z "$USDXYZ_ADDRESS" ]; then
-    echo "⚠️  Warning: USDXYZ_EVM_ADDRESS not found, skipping USDcon balances"
+if [ -z "$USDCON_TOKEN_ADDRESS" ]; then
+    echo "⚠️  Warning: USDCON_EVM_ADDRESS not found, skipping USDcon balances"
     display_balances_connected_evm
 else
-    display_balances_connected_evm "$USDXYZ_ADDRESS"
+    display_balances_connected_evm "$USDCON_TOKEN_ADDRESS"
 fi
 
 # Validate solver balance on Chain 1 (Hub)
@@ -76,11 +76,11 @@ if [ -n "$REQUESTER_CHAIN_HUB_EXPECTED" ] && [ "$REQUESTER_CHAIN_HUB_EXPECTED" !
 fi
 
 # Validate solver balance on Chain 3 (Connected EVM)
-if [ -n "$SOLVER_CHAIN_CONNECTED_EXPECTED" ] && [ "$SOLVER_CHAIN_CONNECTED_EXPECTED" != "-1" ] && [ -n "$USDXYZ_ADDRESS" ]; then
+if [ -n "$SOLVER_CHAIN_CONNECTED_EXPECTED" ] && [ "$SOLVER_CHAIN_CONNECTED_EXPECTED" != "-1" ] && [ -n "$USDCON_TOKEN_ADDRESS" ]; then
     SOLVER_EVM_ADDRESS=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ACCOUNT_INDEX=2 npx hardhat run scripts/get-account-address.js --network localhost" 2>&1 | grep -E '^0x[a-fA-F0-9]{40}$' | head -1)
     
     if [ -n "$SOLVER_EVM_ADDRESS" ]; then
-        SOLVER_CHAIN_CONNECTED_ACTUAL=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && TOKEN_ADDRESS='$USDXYZ_ADDRESS' ACCOUNT='$SOLVER_EVM_ADDRESS' npx hardhat run scripts/get-token-balance.js --network localhost" 2>&1 | grep -E '^[0-9]+$' | tail -1)
+        SOLVER_CHAIN_CONNECTED_ACTUAL=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && TOKEN_ADDRESS='$USDCON_TOKEN_ADDRESS' ACCOUNT='$SOLVER_EVM_ADDRESS' npx hardhat run scripts/get-token-balance.js --network localhost" 2>&1 | grep -E '^[0-9]+$' | tail -1)
         
         if [ "$SOLVER_CHAIN_CONNECTED_ACTUAL" != "$SOLVER_CHAIN_CONNECTED_EXPECTED" ]; then
             log_and_echo "❌ ERROR: Solver balance mismatch on Chain 3 (Connected EVM)!"
@@ -94,11 +94,11 @@ if [ -n "$SOLVER_CHAIN_CONNECTED_EXPECTED" ] && [ "$SOLVER_CHAIN_CONNECTED_EXPEC
 fi
 
 # Validate requester balance on Chain 3 (Connected EVM)
-if [ -n "$REQUESTER_CHAIN_CONNECTED_EXPECTED" ] && [ "$REQUESTER_CHAIN_CONNECTED_EXPECTED" != "-1" ] && [ -n "$USDXYZ_ADDRESS" ]; then
+if [ -n "$REQUESTER_CHAIN_CONNECTED_EXPECTED" ] && [ "$REQUESTER_CHAIN_CONNECTED_EXPECTED" != "-1" ] && [ -n "$USDCON_TOKEN_ADDRESS" ]; then
     REQUESTER_EVM_ADDRESS=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ACCOUNT_INDEX=1 npx hardhat run scripts/get-account-address.js --network localhost" 2>&1 | grep -E '^0x[a-fA-F0-9]{40}$' | head -1)
     
     if [ -n "$REQUESTER_EVM_ADDRESS" ]; then
-        REQUESTER_CHAIN_CONNECTED_ACTUAL=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && TOKEN_ADDRESS='$USDXYZ_ADDRESS' ACCOUNT='$REQUESTER_EVM_ADDRESS' npx hardhat run scripts/get-token-balance.js --network localhost" 2>&1 | grep -E '^[0-9]+$' | tail -1)
+        REQUESTER_CHAIN_CONNECTED_ACTUAL=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && TOKEN_ADDRESS='$USDCON_TOKEN_ADDRESS' ACCOUNT='$REQUESTER_EVM_ADDRESS' npx hardhat run scripts/get-token-balance.js --network localhost" 2>&1 | grep -E '^[0-9]+$' | tail -1)
         
         if [ "$REQUESTER_CHAIN_CONNECTED_ACTUAL" != "$REQUESTER_CHAIN_CONNECTED_EXPECTED" ]; then
             log_and_echo "❌ ERROR: Requester balance mismatch on Chain 3 (Connected EVM)!"

--- a/testing-infra/ci-e2e/e2e-tests-evm/balance-check.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/balance-check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Balance Check Script for EVM E2E Tests
-# Displays and validates final balances for Hub (Chain 1) and Connected EVM (Chain 3)
+# Displays and validates final balances for Hub (Chain 1, USDhub) and Connected EVM (Chain 3, USDcon)
 # Usage: balance-check.sh <solver_chain_hub> <requester_chain_hub> <solver_chain_connected> <requester_chain_connected>
 #   - Pass -1 for any parameter to skip that check
 #   - Values are in 10e-6.USDxyz units (e.g., 2000000 = 2 USDxyz)
@@ -28,14 +28,14 @@ USDXYZ_ADDRESS="$USDXYZ_EVM_ADDRESS"
 
 # Display balances
 if [ -z "$TEST_TOKENS_CHAIN1" ]; then
-    echo "⚠️  Warning: test-tokens-chain1 profile not found, skipping USDxyz balances"
+    echo "⚠️  Warning: test-tokens-chain1 profile not found, skipping USDhub balances"
     display_balances_hub
 else
     display_balances_hub "0x$TEST_TOKENS_CHAIN1"
 fi
 
 if [ -z "$USDXYZ_ADDRESS" ]; then
-    echo "⚠️  Warning: USDXYZ_EVM_ADDRESS not found, skipping USDxyz balances"
+    echo "⚠️  Warning: USDXYZ_EVM_ADDRESS not found, skipping USDcon balances"
     display_balances_connected_evm
 else
     display_balances_connected_evm "$USDXYZ_ADDRESS"
@@ -49,12 +49,12 @@ if [ -n "$SOLVER_CHAIN_HUB_EXPECTED" ] && [ "$SOLVER_CHAIN_HUB_EXPECTED" != "-1"
         
         if [ "$SOLVER_CHAIN_HUB_ACTUAL" != "$SOLVER_CHAIN_HUB_EXPECTED" ]; then
             log_and_echo "❌ ERROR: Solver balance mismatch on Chain 1 (Hub)!"
-            log_and_echo "   Actual:   $SOLVER_CHAIN_HUB_ACTUAL 10e-6.USDxyz"
-            log_and_echo "   Expected: $SOLVER_CHAIN_HUB_EXPECTED 10e-6.USDxyz"
+            log_and_echo "   Actual:   $SOLVER_CHAIN_HUB_ACTUAL 10e-6.USDhub"
+            log_and_echo "   Expected: $SOLVER_CHAIN_HUB_EXPECTED 10e-6.USDhub"
             display_service_logs "Solver balance mismatch on Chain 1 (Hub)"
             exit 1
         fi
-        log_and_echo "✅ Solver balance validated on Chain 1 (Hub): $SOLVER_CHAIN_HUB_ACTUAL 10e-6.USDxyz"
+        log_and_echo "✅ Solver balance validated on Chain 1 (Hub): $SOLVER_CHAIN_HUB_ACTUAL 10e-6.USDhub"
     fi
 fi
 
@@ -66,12 +66,12 @@ if [ -n "$REQUESTER_CHAIN_HUB_EXPECTED" ] && [ "$REQUESTER_CHAIN_HUB_EXPECTED" !
         
         if [ "$REQUESTER_CHAIN_HUB_ACTUAL" != "$REQUESTER_CHAIN_HUB_EXPECTED" ]; then
             log_and_echo "❌ ERROR: Requester balance mismatch on Chain 1 (Hub)!"
-            log_and_echo "   Actual:   $REQUESTER_CHAIN_HUB_ACTUAL 10e-6.USDxyz"
-            log_and_echo "   Expected: $REQUESTER_CHAIN_HUB_EXPECTED 10e-6.USDxyz"
+            log_and_echo "   Actual:   $REQUESTER_CHAIN_HUB_ACTUAL 10e-6.USDhub"
+            log_and_echo "   Expected: $REQUESTER_CHAIN_HUB_EXPECTED 10e-6.USDhub"
             display_service_logs "Requester balance mismatch on Chain 1 (Hub)"
             exit 1
         fi
-        log_and_echo "✅ Requester balance validated on Chain 1 (Hub): $REQUESTER_CHAIN_HUB_ACTUAL 10e-6.USDxyz"
+        log_and_echo "✅ Requester balance validated on Chain 1 (Hub): $REQUESTER_CHAIN_HUB_ACTUAL 10e-6.USDhub"
     fi
 fi
 
@@ -84,12 +84,12 @@ if [ -n "$SOLVER_CHAIN_CONNECTED_EXPECTED" ] && [ "$SOLVER_CHAIN_CONNECTED_EXPEC
         
         if [ "$SOLVER_CHAIN_CONNECTED_ACTUAL" != "$SOLVER_CHAIN_CONNECTED_EXPECTED" ]; then
             log_and_echo "❌ ERROR: Solver balance mismatch on Chain 3 (Connected EVM)!"
-            log_and_echo "   Actual:   $SOLVER_CHAIN_CONNECTED_ACTUAL 10e-6.USDxyz"
-            log_and_echo "   Expected: $SOLVER_CHAIN_CONNECTED_EXPECTED 10e-6.USDxyz"
+            log_and_echo "   Actual:   $SOLVER_CHAIN_CONNECTED_ACTUAL 10e-6.USDcon"
+            log_and_echo "   Expected: $SOLVER_CHAIN_CONNECTED_EXPECTED 10e-6.USDcon"
             display_service_logs "Solver balance mismatch on Chain 3 (Connected EVM)"
             exit 1
         fi
-        log_and_echo "✅ Solver balance validated on Chain 3 (Connected EVM): $SOLVER_CHAIN_CONNECTED_ACTUAL 10e-6.USDxyz"
+        log_and_echo "✅ Solver balance validated on Chain 3 (Connected EVM): $SOLVER_CHAIN_CONNECTED_ACTUAL 10e-6.USDcon"
     fi
 fi
 
@@ -102,12 +102,12 @@ if [ -n "$REQUESTER_CHAIN_CONNECTED_EXPECTED" ] && [ "$REQUESTER_CHAIN_CONNECTED
         
         if [ "$REQUESTER_CHAIN_CONNECTED_ACTUAL" != "$REQUESTER_CHAIN_CONNECTED_EXPECTED" ]; then
             log_and_echo "❌ ERROR: Requester balance mismatch on Chain 3 (Connected EVM)!"
-            log_and_echo "   Actual:   $REQUESTER_CHAIN_CONNECTED_ACTUAL 10e-6.USDxyz"
-            log_and_echo "   Expected: $REQUESTER_CHAIN_CONNECTED_EXPECTED 10e-6.USDxyz"
+            log_and_echo "   Actual:   $REQUESTER_CHAIN_CONNECTED_ACTUAL 10e-6.USDcon"
+            log_and_echo "   Expected: $REQUESTER_CHAIN_CONNECTED_EXPECTED 10e-6.USDcon"
             display_service_logs "Requester balance mismatch on Chain 3 (Connected EVM)"
             exit 1
         fi
-        log_and_echo "✅ Requester balance validated on Chain 3 (Connected EVM): $REQUESTER_CHAIN_CONNECTED_ACTUAL 10e-6.USDxyz"
+        log_and_echo "✅ Requester balance validated on Chain 3 (Connected EVM): $REQUESTER_CHAIN_CONNECTED_ACTUAL 10e-6.USDcon"
     fi
 fi
 

--- a/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-escrow.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-escrow.sh
@@ -84,8 +84,8 @@ log "   - Creating escrow for intent (USDcon ERC20 escrow) with funds..."
 # Reserved solver: Solver - funds will go to Solver when escrow is claimed
 SOLVER_ADDRESS=$(get_hardhat_account_address "2")
 # Escrow amount must match the intent's offered_amount (1 USDcon)
-USDXYZ_AMOUNT="1000000"  # 1 USDcon = 1_000_000 (6 decimals)
-CREATE_OUTPUT=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ESCROW_ADDRESS='$ESCROW_ADDRESS' TOKEN_ADDRESS='$USDCON_TOKEN_ADDRESS' INTENT_ID_EVM='$INTENT_ID_EVM' AMOUNT='$USDXYZ_AMOUNT' RESERVED_SOLVER='$SOLVER_ADDRESS' npx hardhat run scripts/create-escrow-e2e-tests.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
+USDCON_AMOUNT="1000000"  # 1 USDcon = 1_000_000 (6 decimals)
+CREATE_OUTPUT=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ESCROW_ADDRESS='$ESCROW_ADDRESS' TOKEN_ADDRESS='$USDCON_TOKEN_ADDRESS' INTENT_ID_EVM='$INTENT_ID_EVM' AMOUNT='$USDCON_AMOUNT' RESERVED_SOLVER='$SOLVER_ADDRESS' npx hardhat run scripts/create-escrow-e2e-tests.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
 CREATE_EXIT_CODE=$?
 
 # Check if creation was successful

--- a/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-escrow.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-escrow.sh
@@ -43,9 +43,9 @@ EXPIRY_TIME=$(date -d "+1 hour" +%s)
 # Get USDcon token address from chain-info.env
 if [ -f "$PROJECT_ROOT/.tmp/chain-info.env" ]; then
     source "$PROJECT_ROOT/.tmp/chain-info.env"
-    USDXYZ_ADDRESS="$USDXYZ_EVM_ADDRESS"
+    USDCON_TOKEN_ADDRESS="$USDCON_EVM_ADDRESS"
 fi
-if [ -z "$USDXYZ_ADDRESS" ]; then
+if [ -z "$USDCON_TOKEN_ADDRESS" ]; then
     log_and_echo "❌ ERROR: Could not find USDcon token address. Please ensure USDcon is deployed."
     exit 1
 fi
@@ -57,13 +57,13 @@ log ""
 log "🔑 Configuration:"
 log "   Expiry time: $EXPIRY_TIME"
 log "   Intent ID (for escrow): $INTENT_ID"
-log "   USDcon token address: $USDXYZ_ADDRESS"
+log "   USDcon token address: $USDCON_TOKEN_ADDRESS"
 log "   Escrow amount: 1 USDcon (matches intent offered_amount)"
 
 # Check and display initial balances using common function
 log ""
 display_balances_hub "0x$TEST_TOKENS_CHAIN1"
-display_balances_connected_evm "$USDXYZ_ADDRESS"
+display_balances_connected_evm "$USDCON_TOKEN_ADDRESS"
 log_and_echo ""
 
 log ""
@@ -85,7 +85,7 @@ log "   - Creating escrow for intent (USDcon ERC20 escrow) with funds..."
 SOLVER_ADDRESS=$(get_hardhat_account_address "2")
 # Escrow amount must match the intent's offered_amount (1 USDcon)
 USDXYZ_AMOUNT="1000000"  # 1 USDcon = 1_000_000 (6 decimals)
-CREATE_OUTPUT=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ESCROW_ADDRESS='$ESCROW_ADDRESS' TOKEN_ADDRESS='$USDXYZ_ADDRESS' INTENT_ID_EVM='$INTENT_ID_EVM' AMOUNT='$USDXYZ_AMOUNT' RESERVED_SOLVER='$SOLVER_ADDRESS' npx hardhat run scripts/create-escrow-e2e-tests.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
+CREATE_OUTPUT=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ESCROW_ADDRESS='$ESCROW_ADDRESS' TOKEN_ADDRESS='$USDCON_TOKEN_ADDRESS' INTENT_ID_EVM='$INTENT_ID_EVM' AMOUNT='$USDXYZ_AMOUNT' RESERVED_SOLVER='$SOLVER_ADDRESS' npx hardhat run scripts/create-escrow-e2e-tests.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
 CREATE_EXIT_CODE=$?
 
 # Check if creation was successful
@@ -126,7 +126,7 @@ log "   Locked Amount: 1 USDcon (matches intent offered_amount)"
 
 # Check final balances using common function
 display_balances_hub "0x$TEST_TOKENS_CHAIN1"
-display_balances_connected_evm "$USDXYZ_ADDRESS"
+display_balances_connected_evm "$USDCON_TOKEN_ADDRESS"
 log_and_echo ""
 
 

--- a/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-escrow.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-escrow.sh
@@ -40,13 +40,13 @@ log "   Intent ID:              $INTENT_ID"
 
 EXPIRY_TIME=$(date -d "+1 hour" +%s)
 
-# Get USDxyz token address from chain-info.env
+# Get USDcon token address from chain-info.env
 if [ -f "$PROJECT_ROOT/.tmp/chain-info.env" ]; then
     source "$PROJECT_ROOT/.tmp/chain-info.env"
     USDXYZ_ADDRESS="$USDXYZ_EVM_ADDRESS"
 fi
 if [ -z "$USDXYZ_ADDRESS" ]; then
-    log_and_echo "❌ ERROR: Could not find USDxyz token address. Please ensure USDxyz is deployed."
+    log_and_echo "❌ ERROR: Could not find USDcon token address. Please ensure USDcon is deployed."
     exit 1
 fi
 
@@ -57,8 +57,8 @@ log ""
 log "🔑 Configuration:"
 log "   Expiry time: $EXPIRY_TIME"
 log "   Intent ID (for escrow): $INTENT_ID"
-log "   USDxyz token address: $USDXYZ_ADDRESS"
-log "   Escrow amount: 1 USDxyz (matches intent offered_amount)"
+log "   USDcon token address: $USDXYZ_ADDRESS"
+log "   Escrow amount: 1 USDcon (matches intent offered_amount)"
 
 # Check and display initial balances using common function
 log ""
@@ -68,7 +68,7 @@ log_and_echo ""
 
 log ""
 log "   Creating escrow on EVM chain..."
-log "   - Requester locks 1 USDxyz in escrow on Chain 3 (EVM)"
+log "   - Requester locks 1 USDcon in escrow on Chain 3 (EVM)"
 log "   - Requester provides hub chain intent_id when creating escrow"
 log "   - Using intent_id from hub chain: $INTENT_ID"
 log "   - Amount matches intent offered_amount"
@@ -79,12 +79,12 @@ cd evm-intent-framework
 INTENT_ID_EVM=$(convert_intent_id_to_evm "$INTENT_ID")
 log "     Intent ID (EVM): $INTENT_ID_EVM"
 
-# Create escrow for this intent with USDxyz ERC20 token
-log "   - Creating escrow for intent (USDxyz ERC20 escrow) with funds..."
+# Create escrow for this intent with USDcon ERC20 token
+log "   - Creating escrow for intent (USDcon ERC20 escrow) with funds..."
 # Reserved solver: Solver - funds will go to Solver when escrow is claimed
 SOLVER_ADDRESS=$(get_hardhat_account_address "2")
-# Escrow amount must match the intent's offered_amount (1 USDxyz)
-USDXYZ_AMOUNT="1000000"  # 1 USDxyz = 1_000_000 (6 decimals)
+# Escrow amount must match the intent's offered_amount (1 USDcon)
+USDXYZ_AMOUNT="1000000"  # 1 USDcon = 1_000_000 (6 decimals)
 CREATE_OUTPUT=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ESCROW_ADDRESS='$ESCROW_ADDRESS' TOKEN_ADDRESS='$USDXYZ_ADDRESS' INTENT_ID_EVM='$INTENT_ID_EVM' AMOUNT='$USDXYZ_AMOUNT' RESERVED_SOLVER='$SOLVER_ADDRESS' npx hardhat run scripts/create-escrow-e2e-tests.js --network localhost" 2>&1 | tee -a "$LOG_FILE")
 CREATE_EXIT_CODE=$?
 
@@ -117,12 +117,12 @@ log "🎉 ESCROW CREATION COMPLETE!"
 log "============================"
 log ""
 log "✅ Step completed successfully:"
-log "   1. Escrow created on Chain 3 (EVM) with locked USDxyz"
+log "   1. Escrow created on Chain 3 (EVM) with locked USDcon"
 log ""
 log "📋 Escrow Details:"
 log "   Intent ID: $INTENT_ID"
 log "   Escrow Address: $ESCROW_ADDRESS"
-log "   Locked Amount: 1 USDxyz (matches intent offered_amount)"
+log "   Locked Amount: 1 USDcon (matches intent offered_amount)"
 
 # Check final balances using common function
 display_balances_hub "0x$TEST_TOKENS_CHAIN1"

--- a/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-hub-intent.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-hub-intent.sh
@@ -42,7 +42,7 @@ fi
 
 # Get USDcon EVM address
 source "$PROJECT_ROOT/.tmp/chain-info.env" 2>/dev/null || true
-USDXYZ_EVM_ADDRESS="${USDXYZ_EVM_ADDRESS:-}"
+USDCON_EVM_ADDRESS="${USDCON_EVM_ADDRESS:-}"
 
 log ""
 log "📋 Chain Information:"
@@ -72,7 +72,7 @@ log "   Desired amount: $DESIRED_AMOUNT (1 USDhub on hub chain, Chain 1)"
 # Check and display initial balances using common function
 log ""
 display_balances_hub "0x$TEST_TOKENS_CHAIN1"
-display_balances_connected_evm "$USDXYZ_EVM_ADDRESS"
+display_balances_connected_evm "$USDCON_EVM_ADDRESS"
 log_and_echo ""
 
 # Get USDhub metadata addresses (hub) and USDcon metadata (connected) as needed
@@ -85,11 +85,11 @@ log "     ✅ Got USDhub metadata on Chain 1: $USDXYZ_METADATA_CHAIN1"
 # For EVM inflow: offered token is on EVM chain (connected), desired token is on hub
 # Convert 20-byte Ethereum address to 32-byte Move address by padding with zeros
 # Lowercase for consistent matching with solver acceptance config
-EVM_TOKEN_ADDRESS_NO_PREFIX="${USDXYZ_EVM_ADDRESS#0x}"
+EVM_TOKEN_ADDRESS_NO_PREFIX="${USDCON_EVM_ADDRESS#0x}"
 EVM_TOKEN_ADDRESS_LOWER=$(echo "$EVM_TOKEN_ADDRESS_NO_PREFIX" | tr '[:upper:]' '[:lower:]')
 OFFERED_METADATA_EVM="0x000000000000000000000000${EVM_TOKEN_ADDRESS_LOWER}"
 DESIRED_METADATA_CHAIN1="$USDXYZ_METADATA_CHAIN1"
-log "     EVM USDcon token address: $USDXYZ_EVM_ADDRESS"
+log "     EVM USDcon token address: $USDCON_EVM_ADDRESS"
 log "     Padded to 32-byte format: $OFFERED_METADATA_EVM"
 log "     Inflow configuration:"
 log "       Offered metadata (EVM connected chain): $OFFERED_METADATA_EVM"
@@ -250,6 +250,6 @@ save_intent_info "$INTENT_ID" "$HUB_INTENT_ADDRESS"
 
 # Check final balances using common function
 display_balances_hub "0x$TEST_TOKENS_CHAIN1"
-display_balances_connected_evm "$USDXYZ_EVM_ADDRESS"
+display_balances_connected_evm "$USDCON_EVM_ADDRESS"
 log_and_echo ""
 

--- a/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-hub-intent.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-hub-intent.sh
@@ -79,8 +79,8 @@ log_and_echo ""
 log ""
 log "   - Getting USD token metadata addresses..."
 log "     Getting USDhub metadata on Chain 1 (hub)..."
-USDXYZ_METADATA_CHAIN1=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN1" "1")
-log "     ✅ Got USDhub metadata on Chain 1: $USDXYZ_METADATA_CHAIN1"
+USDHUB_METADATA_CHAIN1=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN1" "1")
+log "     ✅ Got USDhub metadata on Chain 1: $USDHUB_METADATA_CHAIN1"
 
 # For EVM inflow: offered token is on EVM chain (connected), desired token is on hub
 # Convert 20-byte Ethereum address to 32-byte Move address by padding with zeros
@@ -88,7 +88,7 @@ log "     ✅ Got USDhub metadata on Chain 1: $USDXYZ_METADATA_CHAIN1"
 EVM_TOKEN_ADDRESS_NO_PREFIX="${USDCON_EVM_ADDRESS#0x}"
 EVM_TOKEN_ADDRESS_LOWER=$(echo "$EVM_TOKEN_ADDRESS_NO_PREFIX" | tr '[:upper:]' '[:lower:]')
 OFFERED_METADATA_EVM="0x000000000000000000000000${EVM_TOKEN_ADDRESS_LOWER}"
-DESIRED_METADATA_CHAIN1="$USDXYZ_METADATA_CHAIN1"
+DESIRED_METADATA_CHAIN1="$USDHUB_METADATA_CHAIN1"
 log "     EVM USDcon token address: $USDCON_EVM_ADDRESS"
 log "     Padded to 32-byte format: $OFFERED_METADATA_EVM"
 log "     Inflow configuration:"

--- a/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-hub-intent.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-hub-intent.sh
@@ -40,7 +40,7 @@ if [ -z "$REQUESTER_EVM_ADDRESS" ]; then
     exit 1
 fi
 
-# Get USDxyz EVM address
+# Get USDcon EVM address
 source "$PROJECT_ROOT/.tmp/chain-info.env" 2>/dev/null || true
 USDXYZ_EVM_ADDRESS="${USDXYZ_EVM_ADDRESS:-}"
 
@@ -55,8 +55,8 @@ EXPIRY_TIME=$(date -d "+1 hour" +%s)
 
 # Generate solver signature using helper function
 # For cross-chain intents: offered tokens are on connected chain, desired tokens are on hub chain (chain 1)
-OFFERED_AMOUNT="1000000"  # 1 USDxyz = 1_000_000 (6 decimals, on EVM chain)
-DESIRED_AMOUNT="1000000"  # 1 USDxyz = 1_000_000 (6 decimals, on hub chain)
+OFFERED_AMOUNT="1000000"  # 1 USDcon = 1_000_000 (6 decimals, on EVM connected chain)
+DESIRED_AMOUNT="1000000"  # 1 USDhub = 1_000_000 (6 decimals, on hub chain)
 OFFERED_CHAIN_ID=$CONNECTED_CHAIN_ID  # Connected chain where escrow will be created (31337 for EVM)
 DESIRED_CHAIN_ID=1  # Hub chain where intent is created
 HUB_CHAIN_ID=1
@@ -66,8 +66,8 @@ log ""
 log "🔑 Configuration:"
 log "   Intent ID: $INTENT_ID"
 log "   Expiry time: $EXPIRY_TIME"
-log "   Offered amount: $OFFERED_AMOUNT (1 USDxyz on connected EVM chain, Chain 3)"
-log "   Desired amount: $DESIRED_AMOUNT (1 USDxyz on hub chain, Chain 1)"
+log "   Offered amount: $OFFERED_AMOUNT (1 USDcon on connected EVM chain, Chain 3)"
+log "   Desired amount: $DESIRED_AMOUNT (1 USDhub on hub chain, Chain 1)"
 
 # Check and display initial balances using common function
 log ""
@@ -75,12 +75,12 @@ display_balances_hub "0x$TEST_TOKENS_CHAIN1"
 display_balances_connected_evm "$USDXYZ_EVM_ADDRESS"
 log_and_echo ""
 
-# Get USDxyz metadata addresses
+# Get USDhub metadata addresses (hub) and USDcon metadata (connected) as needed
 log ""
-log "   - Getting USDxyz metadata addresses..."
-log "     Getting USDxyz metadata on Chain 1 (hub)..."
+log "   - Getting USD token metadata addresses..."
+log "     Getting USDhub metadata on Chain 1 (hub)..."
 USDXYZ_METADATA_CHAIN1=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN1" "1")
-log "     ✅ Got USDxyz metadata on Chain 1: $USDXYZ_METADATA_CHAIN1"
+log "     ✅ Got USDhub metadata on Chain 1: $USDXYZ_METADATA_CHAIN1"
 
 # For EVM inflow: offered token is on EVM chain (connected), desired token is on hub
 # Convert 20-byte Ethereum address to 32-byte Move address by padding with zeros
@@ -89,7 +89,7 @@ EVM_TOKEN_ADDRESS_NO_PREFIX="${USDXYZ_EVM_ADDRESS#0x}"
 EVM_TOKEN_ADDRESS_LOWER=$(echo "$EVM_TOKEN_ADDRESS_NO_PREFIX" | tr '[:upper:]' '[:lower:]')
 OFFERED_METADATA_EVM="0x000000000000000000000000${EVM_TOKEN_ADDRESS_LOWER}"
 DESIRED_METADATA_CHAIN1="$USDXYZ_METADATA_CHAIN1"
-log "     EVM USDxyz token address: $USDXYZ_EVM_ADDRESS"
+log "     EVM USDcon token address: $USDXYZ_EVM_ADDRESS"
 log "     Padded to 32-byte format: $OFFERED_METADATA_EVM"
 log "     Inflow configuration:"
 log "       Offered metadata (EVM connected chain): $OFFERED_METADATA_EVM"

--- a/testing-infra/ci-e2e/e2e-tests-evm/outflow-submit-hub-intent.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/outflow-submit-hub-intent.sh
@@ -32,7 +32,7 @@ TEST_TOKENS_CHAIN1=$(get_profile_address "test-tokens-chain1")
 REQUESTER_CHAIN1_ADDRESS=$(get_profile_address "requester-chain1")
 SOLVER_CHAIN1_ADDRESS=$(get_profile_address "solver-chain1")
 
-# Get EVM addresses and USDxyz token
+# Get EVM addresses and USDcon token
 REQUESTER_EVM_ADDRESS=$(get_hardhat_account_address "1")
 SOLVER_EVM_ADDRESS=$(get_hardhat_account_address "2")
 source "$PROJECT_ROOT/.tmp/chain-info.env" 2>/dev/null || true
@@ -71,8 +71,8 @@ fi
 
 VERIFIER_PUBLIC_KEY="0x${VERIFIER_PUBLIC_KEY_HEX}"
 EXPIRY_TIME=$(date -d "+1 hour" +%s)
-OFFERED_AMOUNT="1000000"  # 1 USDxyz = 1_000_000 (6 decimals, on hub chain)
-DESIRED_AMOUNT="1000000"  # 1 USDxyz = 1_000_000 (6 decimals, on EVM chain)
+OFFERED_AMOUNT="1000000"  # 1 USDhub = 1_000_000 (6 decimals, on hub chain)
+DESIRED_AMOUNT="1000000"  # 1 USDcon = 1_000_000 (6 decimals, on EVM connected chain)
 OFFERED_CHAIN_ID=1
 DESIRED_CHAIN_ID=$CONNECTED_CHAIN_ID
 HUB_CHAIN_ID=1
@@ -82,14 +82,14 @@ log "🔑 Configuration:"
 log "   Intent ID: $INTENT_ID"
 log "   Expiry time: $EXPIRY_TIME"
 log "   Verifier public key: $VERIFIER_PUBLIC_KEY"
-log "   Offered amount: $OFFERED_AMOUNT 10e-6.USDxyz (1 USDxyz on hub chain)"
-log "   Desired amount: $DESIRED_AMOUNT 10e-6.USDxyz (1 USDxyz on EVM chain)"
+log "   Offered amount: $OFFERED_AMOUNT 10e-6.USDhub (1 USDhub on hub chain)"
+log "   Desired amount: $DESIRED_AMOUNT 10e-6.USDcon (1 USDcon on EVM connected chain)"
 
 log ""
-log "   - Getting USDxyz metadata addresses..."
-log "     Getting USDxyz metadata on Chain 1 (hub)..."
+log "   - Getting USD token metadata addresses..."
+log "     Getting USDhub metadata on Chain 1 (hub)..."
 OFFERED_METADATA_CHAIN1=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN1" "1")
-log "     ✅ Got USDxyz metadata on Chain 1: $OFFERED_METADATA_CHAIN1"
+log "     ✅ Got USDhub metadata on Chain 1: $OFFERED_METADATA_CHAIN1"
 
 # For EVM outflow, desired token is on EVM chain (connected chain)
 # Convert 20-byte Ethereum address to 32-byte Move address by padding with zeros
@@ -98,7 +98,7 @@ log "     ✅ Got USDxyz metadata on Chain 1: $OFFERED_METADATA_CHAIN1"
 EVM_TOKEN_ADDRESS_NO_PREFIX="${USDXYZ_ADDRESS#0x}"
 EVM_TOKEN_ADDRESS_LOWER=$(echo "$EVM_TOKEN_ADDRESS_NO_PREFIX" | tr '[:upper:]' '[:lower:]')
 DESIRED_METADATA_EVM="0x000000000000000000000000${EVM_TOKEN_ADDRESS_LOWER}"
-log "     EVM USDxyz token address: $USDXYZ_ADDRESS"
+log "     EVM USDcon token address: $USDXYZ_ADDRESS"
 log "     Padded to 32-byte format: $DESIRED_METADATA_EVM"
 
 # ============================================================================
@@ -198,8 +198,8 @@ log "     Signature: ${RETRIEVED_SIGNATURE:0:20}..."
 # ============================================================================
 log ""
 log "   Creating outflow intent on hub chain..."
-log "   - Requester locks 1 USDxyz on hub chain"
-log "   - Requester wants 1 USDxyz on connected chain (EVM)"
+log "   - Requester locks 1 USDhub on hub chain"
+log "   - Requester wants 1 USDcon on connected chain (EVM)"
 log "     Offered metadata (hub): $OFFERED_METADATA_CHAIN1"
 log "     Desired metadata (connected): $DESIRED_METADATA_EVM"
 log "     Solver address: $RETRIEVED_SOLVER"

--- a/testing-infra/ci-e2e/e2e-tests-evm/outflow-submit-hub-intent.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/outflow-submit-hub-intent.sh
@@ -36,7 +36,7 @@ SOLVER_CHAIN1_ADDRESS=$(get_profile_address "solver-chain1")
 REQUESTER_EVM_ADDRESS=$(get_hardhat_account_address "1")
 SOLVER_EVM_ADDRESS=$(get_hardhat_account_address "2")
 source "$PROJECT_ROOT/.tmp/chain-info.env" 2>/dev/null || true
-USDXYZ_ADDRESS="$USDXYZ_EVM_ADDRESS"
+USDCON_TOKEN_ADDRESS="$USDCON_EVM_ADDRESS"
 
 log ""
 log "📋 Chain Information:"
@@ -95,10 +95,10 @@ log "     ✅ Got USDhub metadata on Chain 1: $OFFERED_METADATA_CHAIN1"
 # Convert 20-byte Ethereum address to 32-byte Move address by padding with zeros
 # e.g., 0x1234...5678 -> 0x0000000000000000000000001234...5678
 # Lowercase for consistent matching with solver acceptance config
-EVM_TOKEN_ADDRESS_NO_PREFIX="${USDXYZ_ADDRESS#0x}"
+EVM_TOKEN_ADDRESS_NO_PREFIX="${USDCON_TOKEN_ADDRESS#0x}"
 EVM_TOKEN_ADDRESS_LOWER=$(echo "$EVM_TOKEN_ADDRESS_NO_PREFIX" | tr '[:upper:]' '[:lower:]')
 DESIRED_METADATA_EVM="0x000000000000000000000000${EVM_TOKEN_ADDRESS_LOWER}"
-log "     EVM USDcon token address: $USDXYZ_ADDRESS"
+log "     EVM USDcon token address: $USDCON_TOKEN_ADDRESS"
 log "     Padded to 32-byte format: $DESIRED_METADATA_EVM"
 
 # ============================================================================
@@ -106,7 +106,7 @@ log "     Padded to 32-byte format: $DESIRED_METADATA_EVM"
 # ============================================================================
 log ""
 display_balances_hub "0x$TEST_TOKENS_CHAIN1"
-display_balances_connected_evm "$USDXYZ_ADDRESS"
+display_balances_connected_evm "$USDCON_TOKEN_ADDRESS"
 log_and_echo ""
 
 # ============================================================================
@@ -244,7 +244,7 @@ fi
 # ============================================================================
 log ""
 display_balances_hub "0x$TEST_TOKENS_CHAIN1"
-display_balances_connected_evm "$USDXYZ_ADDRESS"
+display_balances_connected_evm "$USDCON_TOKEN_ADDRESS"
 log_and_echo ""
 
 log ""

--- a/testing-infra/ci-e2e/e2e-tests-evm/run-tests-inflow.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/run-tests-inflow.sh
@@ -73,7 +73,7 @@ log_and_echo "==================================================================
 log_and_echo ""
 log_and_echo "💰 Pre-Escrow Balance Validation"
 log_and_echo "=========================================="
-log_and_echo "   Nobody should have moved funds yet; all four actors start with 1 USDxyz"
+log_and_echo "   Nobody should have moved funds yet; all four actors start with 1 USDhub/USDcon token on each chain"
 ./testing-infra/ci-e2e/e2e-tests-evm/balance-check.sh 1000000 1000000 1000000 1000000
 
 ./testing-infra/ci-e2e/e2e-tests-evm/inflow-submit-escrow.sh

--- a/testing-infra/ci-e2e/e2e-tests-evm/run-tests-outflow.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/run-tests-outflow.sh
@@ -72,7 +72,7 @@ log_and_echo "   Submitting outflow cross-chain intents via verifier negotiation
 log_and_echo ""
 log_and_echo "💰 Pre-Intent Balance Validation"
 log_and_echo "=========================================="
-log_and_echo "   Everybody starts with 1 USDxyz on their origin chain before outflow"
+log_and_echo "   Everybody starts with 1 USDhub/USDcon on each chain"
 ./testing-infra/ci-e2e/e2e-tests-evm/balance-check.sh 1000000 1000000 1000000 1000000
 
 ./testing-infra/ci-e2e/e2e-tests-evm/outflow-submit-hub-intent.sh

--- a/testing-infra/ci-e2e/e2e-tests-evm/start-solver.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/start-solver.sh
@@ -50,9 +50,9 @@ generate_solver_config_evm() {
     if [ -f "$PROJECT_ROOT/.tmp/chain-info.env" ]; then
         source "$PROJECT_ROOT/.tmp/chain-info.env"
     fi
-    local evm_token_address="${USDXYZ_EVM_ADDRESS:-}"
+    local evm_token_address="${USDCON_EVM_ADDRESS:-}"
     if [ -z "$evm_token_address" ]; then
-        log_and_echo "❌ ERROR: USDXYZ_EVM_ADDRESS not found in chain-info.env"
+        log_and_echo "❌ ERROR: USDCON_EVM_ADDRESS not found in chain-info.env"
         exit 1
     fi
     local escrow_address="${ESCROW_CONTRACT_ADDRESS:-}"

--- a/testing-infra/ci-e2e/e2e-tests-evm/start-solver.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/start-solver.sh
@@ -43,10 +43,10 @@ generate_solver_config_evm() {
     local solver_chain1_address=$(get_profile_address "solver-chain1")
     local chain1_address=$(get_profile_address "intent-account-chain1")
     
-    # Get USDxyz metadata on hub chain (32-byte Move address)
+    # Get USDhub metadata on hub chain (32-byte Move address)
     local usdxyz_metadata_chain1=$(get_usdxyz_metadata "0x${test_tokens_chain1}" "1")
     
-    # Get EVM USDxyz address from chain-info.env and pad to 32 bytes
+    # Get EVM USDcon address from chain-info.env and pad to 32 bytes
     if [ -f "$PROJECT_ROOT/.tmp/chain-info.env" ]; then
         source "$PROJECT_ROOT/.tmp/chain-info.env"
     fi
@@ -83,8 +83,8 @@ generate_solver_config_evm() {
     log "   - Hub module address: $module_address"
     log "   - EVM escrow contract: $escrow_contract"
     log "   - Solver address: $solver_address"
-    log "   - USDxyz metadata (hub): $usdxyz_metadata_chain1"
-    log "   - USDxyz metadata (EVM, padded): $usdxyz_metadata_evm"
+    log "   - USDhub metadata (hub): $usdxyz_metadata_chain1"
+    log "   - USDcon metadata (EVM, padded): $usdxyz_metadata_evm"
     
     cat > "$config_file" << EOF
 # Auto-generated solver config for EVM E2E tests
@@ -110,7 +110,7 @@ escrow_contract_address = "$escrow_contract"
 private_key_env = "$evm_private_key_env"
 
 [acceptance]
-# Accept USDxyz swaps at 1:1 rate for E2E testing
+# Accept USDhub/USDcon swaps at 1:1 rate for E2E testing
 # Inflow: offered on EVM (connected), desired on hub
 "$evm_chain_id:$usdxyz_metadata_evm:$hub_chain_id:$usdxyz_metadata_chain1" = 1.0
 # Outflow: offered on hub, desired on EVM (connected)

--- a/testing-infra/ci-e2e/e2e-tests-evm/start-solver.sh
+++ b/testing-infra/ci-e2e/e2e-tests-evm/start-solver.sh
@@ -44,7 +44,7 @@ generate_solver_config_evm() {
     local chain1_address=$(get_profile_address "intent-account-chain1")
     
     # Get USDhub metadata on hub chain (32-byte Move address)
-    local usdxyz_metadata_chain1=$(get_usdxyz_metadata "0x${test_tokens_chain1}" "1")
+    local usdhub_metadata_chain1=$(get_usdxyz_metadata "0x${test_tokens_chain1}" "1")
     
     # Get EVM USDcon address from chain-info.env and pad to 32 bytes
     if [ -f "$PROJECT_ROOT/.tmp/chain-info.env" ]; then
@@ -63,7 +63,7 @@ generate_solver_config_evm() {
     # Lowercase and pad to 32 bytes for Move compatibility
     local evm_token_no_prefix="${evm_token_address#0x}"
     local evm_token_lower=$(echo "$evm_token_no_prefix" | tr '[:upper:]' '[:lower:]')
-    local usdxyz_metadata_evm="0x000000000000000000000000${evm_token_lower}"
+    local usdcon_metadata_evm="0x000000000000000000000000${evm_token_lower}"
     
     # Use environment variables from test setup
     local verifier_url="${VERIFIER_URL:-http://127.0.0.1:3333}"
@@ -83,8 +83,8 @@ generate_solver_config_evm() {
     log "   - Hub module address: $module_address"
     log "   - EVM escrow contract: $escrow_contract"
     log "   - Solver address: $solver_address"
-    log "   - USDhub metadata (hub): $usdxyz_metadata_chain1"
-    log "   - USDcon metadata (EVM, padded): $usdxyz_metadata_evm"
+    log "   - USDhub metadata (hub): $usdhub_metadata_chain1"
+    log "   - USDcon metadata (EVM, padded): $usdcon_metadata_evm"
     
     cat > "$config_file" << EOF
 # Auto-generated solver config for EVM E2E tests
@@ -112,9 +112,9 @@ private_key_env = "$evm_private_key_env"
 [acceptance]
 # Accept USDhub/USDcon swaps at 1:1 rate for E2E testing
 # Inflow: offered on EVM (connected), desired on hub
-"$evm_chain_id:$usdxyz_metadata_evm:$hub_chain_id:$usdxyz_metadata_chain1" = 1.0
+"$evm_chain_id:$usdcon_metadata_evm:$hub_chain_id:$usdhub_metadata_chain1" = 1.0
 # Outflow: offered on hub, desired on EVM (connected)
-"$hub_chain_id:$usdxyz_metadata_chain1:$evm_chain_id:$usdxyz_metadata_evm" = 1.0
+"$hub_chain_id:$usdhub_metadata_chain1:$evm_chain_id:$usdcon_metadata_evm" = 1.0
 
 [solver]
 profile = "solver-chain1"

--- a/testing-infra/ci-e2e/e2e-tests-mvm/balance-check.sh
+++ b/testing-infra/ci-e2e/e2e-tests-mvm/balance-check.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Balance Check Script for MVM E2E Tests
-# Displays and validates final balances for Hub (Chain 1) and Connected MVM (Chain 2)
+# Displays and validates final balances for Hub (Chain 1, USDhub) and Connected MVM (Chain 2, USDcon)
 # Usage: balance-check.sh <solver_chain_hub> <requester_chain_hub> <solver_chain_connected> <requester_chain_connected>
 #   - Pass -1 for any parameter to skip that check
-#   - Values are in 10e-6.USDxyz units (e.g., 2000000 = 2 USDxyz)
+#   - Values are in 10e-6 units (e.g., 2000000 = 2 tokens: USDhub on Chain 1, USDcon on Chain 2)
 
 # Source common utilities
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -26,14 +26,14 @@ TEST_TOKENS_CHAIN2=$(get_profile_address "test-tokens-chain2" 2>/dev/null) || tr
 
 # Display balances
 if [ -z "$TEST_TOKENS_CHAIN1" ]; then
-    echo "⚠️  Warning: test-tokens-chain1 profile not found, skipping USDxyz balances"
+    echo "⚠️  Warning: test-tokens-chain1 profile not found, skipping USDhub balances"
     display_balances_hub
 else
     display_balances_hub "0x$TEST_TOKENS_CHAIN1"
 fi
 
 if [ -z "$TEST_TOKENS_CHAIN2" ]; then
-    echo "⚠️  Warning: test-tokens-chain2 profile not found, skipping USDxyz balances"
+    echo "⚠️  Warning: test-tokens-chain2 profile not found, skipping USDcon balances"
     display_balances_connected_mvm
 else
     display_balances_connected_mvm "0x$TEST_TOKENS_CHAIN2"
@@ -47,12 +47,12 @@ if [ -n "$SOLVER_CHAIN_HUB_EXPECTED" ] && [ "$SOLVER_CHAIN_HUB_EXPECTED" != "-1"
         
         if [ "$SOLVER_CHAIN_HUB_ACTUAL" != "$SOLVER_CHAIN_HUB_EXPECTED" ]; then
             log_and_echo "❌ ERROR: Solver balance mismatch on Chain 1 (Hub)!"
-            log_and_echo "   Actual:   $SOLVER_CHAIN_HUB_ACTUAL 10e-6.USDxyz"
-            log_and_echo "   Expected: $SOLVER_CHAIN_HUB_EXPECTED 10e-6.USDxyz"
+            log_and_echo "   Actual:   $SOLVER_CHAIN_HUB_ACTUAL 10e-6.USDhub"
+            log_and_echo "   Expected: $SOLVER_CHAIN_HUB_EXPECTED 10e-6.USDhub"
             display_service_logs "Solver balance mismatch on Chain 1 (Hub)"
             exit 1
         fi
-        log_and_echo "✅ Solver balance validated on Chain 1 (Hub): $SOLVER_CHAIN_HUB_ACTUAL 10e-6.USDxyz"
+        log_and_echo "✅ Solver balance validated on Chain 1 (Hub): $SOLVER_CHAIN_HUB_ACTUAL 10e-6.USDhub"
     fi
 fi
 
@@ -64,12 +64,12 @@ if [ -n "$REQUESTER_CHAIN_HUB_EXPECTED" ] && [ "$REQUESTER_CHAIN_HUB_EXPECTED" !
         
         if [ "$REQUESTER_CHAIN_HUB_ACTUAL" != "$REQUESTER_CHAIN_HUB_EXPECTED" ]; then
             log_and_echo "❌ ERROR: Requester balance mismatch on Chain 1 (Hub)!"
-            log_and_echo "   Actual:   $REQUESTER_CHAIN_HUB_ACTUAL 10e-6.USDxyz"
-            log_and_echo "   Expected: $REQUESTER_CHAIN_HUB_EXPECTED 10e-6.USDxyz"
+            log_and_echo "   Actual:   $REQUESTER_CHAIN_HUB_ACTUAL 10e-6.USDhub"
+            log_and_echo "   Expected: $REQUESTER_CHAIN_HUB_EXPECTED 10e-6.USDhub"
             display_service_logs "Requester balance mismatch on Chain 1 (Hub)"
             exit 1
         fi
-        log_and_echo "✅ Requester balance validated on Chain 1 (Hub): $REQUESTER_CHAIN_HUB_ACTUAL 10e-6.USDxyz"
+        log_and_echo "✅ Requester balance validated on Chain 1 (Hub): $REQUESTER_CHAIN_HUB_ACTUAL 10e-6.USDhub"
     fi
 fi
 
@@ -81,12 +81,12 @@ if [ -n "$SOLVER_CHAIN_CONNECTED_EXPECTED" ] && [ "$SOLVER_CHAIN_CONNECTED_EXPEC
         
         if [ "$SOLVER_CHAIN_CONNECTED_ACTUAL" != "$SOLVER_CHAIN_CONNECTED_EXPECTED" ]; then
             log_and_echo "❌ ERROR: Solver balance mismatch on Chain 2 (Connected MVM)!"
-            log_and_echo "   Actual:   $SOLVER_CHAIN_CONNECTED_ACTUAL 10e-6.USDxyz"
-            log_and_echo "   Expected: $SOLVER_CHAIN_CONNECTED_EXPECTED 10e-6.USDxyz"
+            log_and_echo "   Actual:   $SOLVER_CHAIN_CONNECTED_ACTUAL 10e-6.USDcon"
+            log_and_echo "   Expected: $SOLVER_CHAIN_CONNECTED_EXPECTED 10e-6.USDcon"
             display_service_logs "Solver balance mismatch on Chain 2 (Connected MVM)"
             exit 1
         fi
-        log_and_echo "✅ Solver balance validated on Chain 2 (Connected MVM): $SOLVER_CHAIN_CONNECTED_ACTUAL 10e-6.USDxyz"
+        log_and_echo "✅ Solver balance validated on Chain 2 (Connected MVM): $SOLVER_CHAIN_CONNECTED_ACTUAL 10e-6.USDcon"
     fi
 fi
 
@@ -98,12 +98,12 @@ if [ -n "$REQUESTER_CHAIN_CONNECTED_EXPECTED" ] && [ "$REQUESTER_CHAIN_CONNECTED
         
         if [ "$REQUESTER_CHAIN_CONNECTED_ACTUAL" != "$REQUESTER_CHAIN_CONNECTED_EXPECTED" ]; then
             log_and_echo "❌ ERROR: Requester balance mismatch on Chain 2 (Connected MVM)!"
-            log_and_echo "   Actual:   $REQUESTER_CHAIN_CONNECTED_ACTUAL 10e-6.USDxyz"
-            log_and_echo "   Expected: $REQUESTER_CHAIN_CONNECTED_EXPECTED 10e-6.USDxyz"
+            log_and_echo "   Actual:   $REQUESTER_CHAIN_CONNECTED_ACTUAL 10e-6.USDcon"
+            log_and_echo "   Expected: $REQUESTER_CHAIN_CONNECTED_EXPECTED 10e-6.USDcon"
             display_service_logs "Requester balance mismatch on Chain 2 (Connected MVM)"
             exit 1
         fi
-        log_and_echo "✅ Requester balance validated on Chain 2 (Connected MVM): $REQUESTER_CHAIN_CONNECTED_ACTUAL 10e-6.USDxyz"
+        log_and_echo "✅ Requester balance validated on Chain 2 (Connected MVM): $REQUESTER_CHAIN_CONNECTED_ACTUAL 10e-6.USDcon"
     fi
 fi
 

--- a/testing-infra/ci-e2e/e2e-tests-mvm/inflow-submit-escrow.sh
+++ b/testing-infra/ci-e2e/e2e-tests-mvm/inflow-submit-escrow.sh
@@ -74,13 +74,13 @@ log "   Intent ID: $INTENT_ID"
 
 log ""
 log "   - Getting USDcon metadata on Chain 2..."
-USDXYZ_METADATA_CHAIN2=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN2" "2")
-if [ -z "$USDXYZ_METADATA_CHAIN2" ]; then
+USDCON_METADATA_CHAIN2=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN2" "2")
+if [ -z "$USDCON_METADATA_CHAIN2" ]; then
     log_and_echo "❌ Failed to get USDcon metadata on Chain 2"
     exit 1
 fi
-log "     ✅ Got USDcon metadata on Chain 2: $USDXYZ_METADATA_CHAIN2"
-OFFERED_METADATA_CHAIN2="$USDXYZ_METADATA_CHAIN2"
+log "     ✅ Got USDcon metadata on Chain 2: $USDCON_METADATA_CHAIN2"
+OFFERED_METADATA_CHAIN2="$USDCON_METADATA_CHAIN2"
 
 # ============================================================================
 # SECTION 3: DISPLAY INITIAL STATE

--- a/testing-infra/ci-e2e/e2e-tests-mvm/inflow-submit-escrow.sh
+++ b/testing-infra/ci-e2e/e2e-tests-mvm/inflow-submit-escrow.sh
@@ -73,13 +73,13 @@ log "   Expiry time: $EXPIRY_TIME"
 log "   Intent ID: $INTENT_ID"
 
 log ""
-log "   - Getting USDxyz metadata on Chain 2..."
+log "   - Getting USDcon metadata on Chain 2..."
 USDXYZ_METADATA_CHAIN2=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN2" "2")
 if [ -z "$USDXYZ_METADATA_CHAIN2" ]; then
-    log_and_echo "❌ Failed to get USDxyz metadata on Chain 2"
+    log_and_echo "❌ Failed to get USDcon metadata on Chain 2"
     exit 1
 fi
-log "     ✅ Got USDxyz metadata on Chain 2: $USDXYZ_METADATA_CHAIN2"
+log "     ✅ Got USDcon metadata on Chain 2: $USDXYZ_METADATA_CHAIN2"
 OFFERED_METADATA_CHAIN2="$USDXYZ_METADATA_CHAIN2"
 
 # ============================================================================
@@ -95,14 +95,14 @@ log_and_echo ""
 # ============================================================================
 log ""
 log "   Creating escrow on connected chain..."
-log "   - Requester (Requester) locks 1 USDxyz in escrow on Chain 2 (connected chain)"
+log "   - Requester (Requester) locks 1 USDcon in escrow on Chain 2 (connected chain)"
 log "   - Using intent_id from hub chain: $INTENT_ID"
 
 # DEBUG: Check requester balance BEFORE escrow creation
 log ""
 log "   DEBUG: Checking requester balance BEFORE escrow creation..."
 BEFORE_BALANCE=$(get_usdxyz_balance "requester-chain2" "2" "0x$TEST_TOKENS_CHAIN2")
-log_and_echo "   DEBUG: Requester USDxyz balance BEFORE escrow: $BEFORE_BALANCE"
+log_and_echo "   DEBUG: Requester USDcon balance BEFORE escrow: $BEFORE_BALANCE"
 
 log "   - Creating escrow intent on Chain 2..."
 log "     Offered metadata: $OFFERED_METADATA_CHAIN2"
@@ -126,7 +126,7 @@ if [ $ESCROW_EXIT_CODE -eq 0 ]; then
     log ""
     log "   DEBUG: Checking requester balance AFTER escrow creation..."
     AFTER_BALANCE=$(get_usdxyz_balance "requester-chain2" "2" "0x$TEST_TOKENS_CHAIN2")
-    log_and_echo "   DEBUG: Requester USDxyz balance AFTER escrow: $AFTER_BALANCE"
+    log_and_echo "   DEBUG: Requester USDcon balance AFTER escrow: $AFTER_BALANCE"
     
     if [ "$BEFORE_BALANCE" = "$AFTER_BALANCE" ]; then
         log_and_echo "   ⚠️  WARNING: Requester balance did NOT change after escrow creation!"
@@ -178,10 +178,10 @@ if [ $ESCROW_EXIT_CODE -eq 0 ]; then
     fi
 
     if [ "$LOCKED_AMOUNT" = "1000000" ]; then
-        log "     ✅ Escrow has correct locked amount (1 USDxyz)"
+        log "     ✅ Escrow has correct locked amount (1 USDcon)"
     else
         log_and_echo "❌ ERROR: Escrow has unexpected locked amount: $LOCKED_AMOUNT"
-        log_and_echo "   Expected: 100_000_000 (1 USDxyz)"
+        log_and_echo "   Expected: 100_000_000 (1 USDcon)"
         exit 1
     fi
 

--- a/testing-infra/ci-e2e/e2e-tests-mvm/inflow-submit-hub-intent.sh
+++ b/testing-infra/ci-e2e/e2e-tests-mvm/inflow-submit-hub-intent.sh
@@ -62,24 +62,24 @@ log "   Desired amount: $DESIRED_AMOUNT (1 USDhub on hub chain, Chain 1)"
 log ""
 log "   - Getting USD token metadata addresses..."
 log "     Getting USDhub metadata on Chain 1..."
-USDXYZ_METADATA_CHAIN1=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN1" "1")
-if [ -z "$USDXYZ_METADATA_CHAIN1" ]; then
+USDHUB_METADATA_CHAIN1=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN1" "1")
+if [ -z "$USDHUB_METADATA_CHAIN1" ]; then
     log_and_echo "❌ Failed to get USDhub metadata on Chain 1"
     exit 1
 fi
-log "     ✅ Got USDhub metadata on Chain 1: $USDXYZ_METADATA_CHAIN1"
+log "     ✅ Got USDhub metadata on Chain 1: $USDHUB_METADATA_CHAIN1"
 
 log "     Getting USDcon metadata on Chain 2..."
-USDXYZ_METADATA_CHAIN2=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN2" "2")
-if [ -z "$USDXYZ_METADATA_CHAIN2" ]; then
+USDCON_METADATA_CHAIN2=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN2" "2")
+if [ -z "$USDCON_METADATA_CHAIN2" ]; then
     log_and_echo "❌ Failed to get USDcon metadata on Chain 2"
     exit 1
 fi
-log "     ✅ Got USDcon metadata on Chain 2: $USDXYZ_METADATA_CHAIN2"
+log "     ✅ Got USDcon metadata on Chain 2: $USDCON_METADATA_CHAIN2"
 
 # For INFLOW: offered tokens are on connected chain (Chain 2), desired tokens are on hub (Chain 1)
-OFFERED_METADATA_CHAIN2="$USDXYZ_METADATA_CHAIN2"
-DESIRED_METADATA_CHAIN1="$USDXYZ_METADATA_CHAIN1"
+OFFERED_METADATA_CHAIN2="$USDCON_METADATA_CHAIN2"
+DESIRED_METADATA_CHAIN1="$USDHUB_METADATA_CHAIN1"
 log "     Inflow configuration:"
 log "       Offered metadata (connected chain 2): $OFFERED_METADATA_CHAIN2"
 log "       Desired metadata (hub chain 1): $DESIRED_METADATA_CHAIN1"

--- a/testing-infra/ci-e2e/e2e-tests-mvm/inflow-submit-hub-intent.sh
+++ b/testing-infra/ci-e2e/e2e-tests-mvm/inflow-submit-hub-intent.sh
@@ -44,9 +44,9 @@ log "   Requester Chain 2 (connected): $REQUESTER_CHAIN2_ADDRESS"
 log "   Solver Chain 2 (connected): $SOLVER_CHAIN2_ADDRESS"
 
 EXPIRY_TIME=$(date -d "+1 hour" +%s)
-# Requester and Solver get funded with 1 USDxyz each, transfer 1 USDxyz
-OFFERED_AMOUNT="1000000"  # 1 USDxyz (6 decimals = 1_000_000)
-DESIRED_AMOUNT="1000000"  # 1 USDxyz (6 decimals = 1_000_000)
+# Requester and Solver get funded with 1 USDhub / 1 USDcon each (6 decimals = 1_000_000)
+OFFERED_AMOUNT="1000000"  # 1 USDcon (connected chain, 6 decimals = 1_000_000)
+DESIRED_AMOUNT="1000000"  # 1 USDhub (hub chain, 6 decimals = 1_000_000)
 OFFERED_CHAIN_ID=$CONNECTED_CHAIN_ID
 DESIRED_CHAIN_ID=1
 HUB_CHAIN_ID=1
@@ -56,26 +56,26 @@ log ""
 log "🔑 Configuration:"
 log "   Intent ID: $INTENT_ID"
 log "   Expiry time: $EXPIRY_TIME"
-log "   Offered amount: $OFFERED_AMOUNT (1 USDxyz on connected MVM chain, Chain 2)"
-log "   Desired amount: $DESIRED_AMOUNT (1 USDxyz on hub chain, Chain 1)"
+log "   Offered amount: $OFFERED_AMOUNT (1 USDcon on connected MVM chain, Chain 2)"
+log "   Desired amount: $DESIRED_AMOUNT (1 USDhub on hub chain, Chain 1)"
 
 log ""
-log "   - Getting USDxyz metadata addresses..."
-log "     Getting USDxyz metadata on Chain 1..."
+log "   - Getting USD token metadata addresses..."
+log "     Getting USDhub metadata on Chain 1..."
 USDXYZ_METADATA_CHAIN1=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN1" "1")
 if [ -z "$USDXYZ_METADATA_CHAIN1" ]; then
-    log_and_echo "❌ Failed to get USDxyz metadata on Chain 1"
+    log_and_echo "❌ Failed to get USDhub metadata on Chain 1"
     exit 1
 fi
-log "     ✅ Got USDxyz metadata on Chain 1: $USDXYZ_METADATA_CHAIN1"
+log "     ✅ Got USDhub metadata on Chain 1: $USDXYZ_METADATA_CHAIN1"
 
-log "     Getting USDxyz metadata on Chain 2..."
+log "     Getting USDcon metadata on Chain 2..."
 USDXYZ_METADATA_CHAIN2=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN2" "2")
 if [ -z "$USDXYZ_METADATA_CHAIN2" ]; then
-    log_and_echo "❌ Failed to get USDxyz metadata on Chain 2"
+    log_and_echo "❌ Failed to get USDcon metadata on Chain 2"
     exit 1
 fi
-log "     ✅ Got USDxyz metadata on Chain 2: $USDXYZ_METADATA_CHAIN2"
+log "     ✅ Got USDcon metadata on Chain 2: $USDXYZ_METADATA_CHAIN2"
 
 # For INFLOW: offered tokens are on connected chain (Chain 2), desired tokens are on hub (Chain 1)
 OFFERED_METADATA_CHAIN2="$USDXYZ_METADATA_CHAIN2"

--- a/testing-infra/ci-e2e/e2e-tests-mvm/outflow-submit-hub-intent.sh
+++ b/testing-infra/ci-e2e/e2e-tests-mvm/outflow-submit-hub-intent.sh
@@ -68,9 +68,9 @@ fi
 
 VERIFIER_PUBLIC_KEY="0x${VERIFIER_PUBLIC_KEY_HEX}"
 EXPIRY_TIME=$(date -d "+1 hour" +%s)
-# USDxyz amounts: 1 USDxyz (6 decimals = 1_000_000)
-OFFERED_AMOUNT="1000000"  # 1 USDxyz = 1_000_000
-DESIRED_AMOUNT="1000000"  # 1 USDxyz = 1_000_000
+# Token amounts: 1 USDhub / 1 USDcon (6 decimals = 1_000_000)
+OFFERED_AMOUNT="1000000"  # 1 USDhub = 1_000_000 (6 decimals, on hub chain)
+DESIRED_AMOUNT="1000000"  # 1 USDcon = 1_000_000 (6 decimals, on connected MVM chain)
 OFFERED_CHAIN_ID=1
 DESIRED_CHAIN_ID=$CONNECTED_CHAIN_ID
 HUB_CHAIN_ID=1
@@ -81,23 +81,23 @@ log "🔑 Configuration:"
 log "   Intent ID: $INTENT_ID"
 log "   Expiry time: $EXPIRY_TIME"
 log "   Verifier public key: $VERIFIER_PUBLIC_KEY"
-log "   Offered amount: $OFFERED_AMOUNT (1 USDxyz)"
-log "   Desired amount: $DESIRED_AMOUNT (1 USDxyz)"
+log "   Offered amount: $OFFERED_AMOUNT (1 USDhub on hub chain)"
+log "   Desired amount: $DESIRED_AMOUNT (1 USDcon on connected MVM chain)"
 
 # Get test tokens addresses from profiles
 TEST_TOKENS_CHAIN1=$(get_profile_address "test-tokens-chain1")
 TEST_TOKENS_CHAIN2=$(get_profile_address "test-tokens-chain2")
 
 log ""
-log "   - Getting USDxyz metadata addresses..."
-log "     Getting USDxyz metadata on Chain 1..."
+log "   - Getting USD token metadata addresses..."
+log "     Getting USDhub metadata on Chain 1..."
 USDXYZ_METADATA_CHAIN1=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN1" "1")
-log "     ✅ Got USDxyz metadata on Chain 1: $USDXYZ_METADATA_CHAIN1"
+log "     ✅ Got USDhub metadata on Chain 1: $USDXYZ_METADATA_CHAIN1"
 OFFERED_METADATA_CHAIN1="$USDXYZ_METADATA_CHAIN1"
 
-log "     Getting USDxyz metadata on Chain 2..."
+log "     Getting USDcon metadata on Chain 2..."
 USDXYZ_METADATA_CHAIN2=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN2" "2")
-log "     ✅ Got USDxyz metadata on Chain 2: $USDXYZ_METADATA_CHAIN2"
+log "     ✅ Got USDcon metadata on Chain 2: $USDXYZ_METADATA_CHAIN2"
 DESIRED_METADATA_CHAIN2="$USDXYZ_METADATA_CHAIN2"
 
 # ============================================================================
@@ -197,8 +197,8 @@ log "     Signature: ${RETRIEVED_SIGNATURE:0:20}..."
 # ============================================================================
 log ""
 log "   Creating outflow intent on hub chain..."
-log "   - Requester locks 1 USDxyz on hub chain"
-log "   - Requester wants 1 USDxyz on connected chain (Chain 2)"
+log "   - Requester locks 1 USDhub on hub chain"
+log "   - Requester wants 1 USDcon on connected chain (Chain 2)"
 log "     Offered metadata (hub): $OFFERED_METADATA_CHAIN1"
 log "     Desired metadata (connected): $DESIRED_METADATA_CHAIN2"
 log "     Solver address: $RETRIEVED_SOLVER"

--- a/testing-infra/ci-e2e/e2e-tests-mvm/outflow-submit-hub-intent.sh
+++ b/testing-infra/ci-e2e/e2e-tests-mvm/outflow-submit-hub-intent.sh
@@ -91,14 +91,14 @@ TEST_TOKENS_CHAIN2=$(get_profile_address "test-tokens-chain2")
 log ""
 log "   - Getting USD token metadata addresses..."
 log "     Getting USDhub metadata on Chain 1..."
-USDXYZ_METADATA_CHAIN1=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN1" "1")
-log "     ✅ Got USDhub metadata on Chain 1: $USDXYZ_METADATA_CHAIN1"
-OFFERED_METADATA_CHAIN1="$USDXYZ_METADATA_CHAIN1"
+USDHUB_METADATA_CHAIN1=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN1" "1")
+log "     ✅ Got USDhub metadata on Chain 1: $USDHUB_METADATA_CHAIN1"
+OFFERED_METADATA_CHAIN1="$USDHUB_METADATA_CHAIN1"
 
 log "     Getting USDcon metadata on Chain 2..."
-USDXYZ_METADATA_CHAIN2=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN2" "2")
-log "     ✅ Got USDcon metadata on Chain 2: $USDXYZ_METADATA_CHAIN2"
-DESIRED_METADATA_CHAIN2="$USDXYZ_METADATA_CHAIN2"
+USDCON_METADATA_CHAIN2=$(get_usdxyz_metadata "0x$TEST_TOKENS_CHAIN2" "2")
+log "     ✅ Got USDcon metadata on Chain 2: $USDCON_METADATA_CHAIN2"
+DESIRED_METADATA_CHAIN2="$USDCON_METADATA_CHAIN2"
 
 # ============================================================================
 # SECTION 3: DISPLAY INITIAL STATE

--- a/testing-infra/ci-e2e/e2e-tests-mvm/run-tests-inflow.sh
+++ b/testing-infra/ci-e2e/e2e-tests-mvm/run-tests-inflow.sh
@@ -69,7 +69,7 @@ echo "   Submitting inflow cross-chain intents via verifier negotiation routing.
 echo ""
 echo "💰 Pre-Escrow Balance Validation"
 echo "=========================================="
-# Nobody should have done anything yet: all four actors start with 1 USDxyz
+# Nobody should have done anything yet: all four actors start with 1 USDhub/USDcon on each chain
 ./testing-infra/ci-e2e/e2e-tests-mvm/balance-check.sh 1000000 1000000 1000000 1000000
 
 ./testing-infra/ci-e2e/e2e-tests-mvm/inflow-submit-escrow.sh

--- a/testing-infra/ci-e2e/e2e-tests-mvm/run-tests-outflow.sh
+++ b/testing-infra/ci-e2e/e2e-tests-mvm/run-tests-outflow.sh
@@ -56,7 +56,7 @@ echo "🚀 Step 4: Configuring and starting verifier (for negotiation routing)..
 echo "=========================================================================="
 ./testing-infra/ci-e2e/e2e-tests-mvm/start-verifier.sh
 
-# Assert solver has USDxyz before starting (should have 1 USDxyz from deploy)
+# Assert solver has USDcon before starting (should have 1 USDcon from deploy)
 assert_usdxyz_balance "solver-chain2" "2" "$TEST_TOKENS_CHAIN2_ADDRESS" "1000000" "pre-solver-start"
 echo "   [DEBUG] Balance assertion completed, continuing..."
 
@@ -76,7 +76,7 @@ echo "   Submitting outflow cross-chain intents via verifier negotiation routing
 echo ""
 echo "💰 Pre-Intent Balance Validation"
 echo "=========================================="
-# Everybody starts with 1 USDxyz on their origin chain before outflow
+# Everybody starts with 1 USDhub/USDcon on each chain
 ./testing-infra/ci-e2e/e2e-tests-mvm/balance-check.sh 1000000 1000000 1000000 1000000
 
 ./testing-infra/ci-e2e/e2e-tests-mvm/outflow-submit-hub-intent.sh

--- a/testing-infra/ci-e2e/e2e-tests-mvm/start-solver.sh
+++ b/testing-infra/ci-e2e/e2e-tests-mvm/start-solver.sh
@@ -41,7 +41,7 @@ generate_solver_config_mvm() {
     local test_tokens_chain1=$(get_profile_address "test-tokens-chain1")
     local test_tokens_chain2=$(get_profile_address "test-tokens-chain2")
     
-    # Get USDxyz metadata addresses (for acceptance config)
+    # Get USDhub/USDcon metadata addresses (for acceptance config)
     local usdxyz_metadata_chain1=$(get_usdxyz_metadata "0x${test_tokens_chain1}" "1")
     local usdxyz_metadata_chain2=$(get_usdxyz_metadata "0x${test_tokens_chain2}" "2")
     
@@ -62,8 +62,8 @@ generate_solver_config_mvm() {
     log "   - Hub module address: $hub_module_address"
     log "   - Connected module address: $connected_module_address"
     log "   - Solver address: $solver_address"
-    log "   - USDxyz metadata chain 1: $usdxyz_metadata_chain1"
-    log "   - USDxyz metadata chain 2: $usdxyz_metadata_chain2"
+    log "   - USDhub metadata chain 1: $usdxyz_metadata_chain1"
+    log "   - USDcon metadata chain 2: $usdxyz_metadata_chain2"
     
     cat > "$config_file" << EOF
 # Auto-generated solver config for MVM E2E tests
@@ -89,7 +89,7 @@ module_address = "$connected_module_address"
 profile = "solver-chain2"
 
 [acceptance]
-# Accept USDxyz swaps at 1:1 rate for E2E testing
+# Accept USDhub/USDcon swaps at 1:1 rate for E2E testing
 # Inflow: offered on connected chain (2), desired on hub chain (1)
 "$connected_chain_id:$usdxyz_metadata_chain2:$hub_chain_id:$usdxyz_metadata_chain1" = 1.0
 # Outflow: offered on hub chain (1), desired on connected chain (2)

--- a/testing-infra/ci-e2e/e2e-tests-mvm/start-solver.sh
+++ b/testing-infra/ci-e2e/e2e-tests-mvm/start-solver.sh
@@ -42,8 +42,8 @@ generate_solver_config_mvm() {
     local test_tokens_chain2=$(get_profile_address "test-tokens-chain2")
     
     # Get USDhub/USDcon metadata addresses (for acceptance config)
-    local usdxyz_metadata_chain1=$(get_usdxyz_metadata "0x${test_tokens_chain1}" "1")
-    local usdxyz_metadata_chain2=$(get_usdxyz_metadata "0x${test_tokens_chain2}" "2")
+    local usdhub_metadata_chain1=$(get_usdxyz_metadata "0x${test_tokens_chain1}" "1")
+    local usdcon_metadata_chain2=$(get_usdxyz_metadata "0x${test_tokens_chain2}" "2")
     
     # Use environment variables or defaults for URLs
     local verifier_url="${VERIFIER_URL:-http://127.0.0.1:3333}"
@@ -62,8 +62,8 @@ generate_solver_config_mvm() {
     log "   - Hub module address: $hub_module_address"
     log "   - Connected module address: $connected_module_address"
     log "   - Solver address: $solver_address"
-    log "   - USDhub metadata chain 1: $usdxyz_metadata_chain1"
-    log "   - USDcon metadata chain 2: $usdxyz_metadata_chain2"
+    log "   - USDhub metadata chain 1: $usdhub_metadata_chain1"
+    log "   - USDcon metadata chain 2: $usdcon_metadata_chain2"
     
     cat > "$config_file" << EOF
 # Auto-generated solver config for MVM E2E tests
@@ -91,9 +91,9 @@ profile = "solver-chain2"
 [acceptance]
 # Accept USDhub/USDcon swaps at 1:1 rate for E2E testing
 # Inflow: offered on connected chain (2), desired on hub chain (1)
-"$connected_chain_id:$usdxyz_metadata_chain2:$hub_chain_id:$usdxyz_metadata_chain1" = 1.0
+"$connected_chain_id:$usdcon_metadata_chain2:$hub_chain_id:$usdhub_metadata_chain1" = 1.0
 # Outflow: offered on hub chain (1), desired on connected chain (2)
-"$hub_chain_id:$usdxyz_metadata_chain1:$connected_chain_id:$usdxyz_metadata_chain2" = 1.0
+"$hub_chain_id:$usdhub_metadata_chain1:$connected_chain_id:$usdcon_metadata_chain2" = 1.0
 
 [solver]
 profile = "solver-chain1"

--- a/testing-infra/ci-e2e/util_evm.sh
+++ b/testing-infra/ci-e2e/util_evm.sh
@@ -9,16 +9,16 @@
 # Note: This file depends on functions from util.sh (log, log_and_echo, setup_project_root, etc.)
 
 # Get USDcon balance for an EVM account
-# Usage: get_usdxyz_balance_evm <account_address> <usd_token_address>
+# Usage: get_usdcon_balance_evm <account_address> <usd_token_address>
 # Returns the USDcon balance for the given account
 # PANICS if inputs are missing or balance lookup fails
-get_usdxyz_balance_evm() {
+get_usdcon_balance_evm() {
     local account="$1"
     local token_address="$2"
     
     # Validate inputs
     if [ -z "$account" ] || [ -z "$token_address" ]; then
-        echo "❌ PANIC: get_usdxyz_balance_evm requires account and token_address" >&2
+        echo "❌ PANIC: get_usdcon_balance_evm requires account and token_address" >&2
         echo "   account: '$account', token_address: '$token_address'" >&2
         exit 1
     fi
@@ -31,7 +31,7 @@ get_usdxyz_balance_evm() {
     local balance=$(echo "$balance_output" | grep -E '^[0-9]+$' | tail -1 | tr -d '\n')
     
     if [ -z "$balance" ]; then
-        echo "❌ PANIC: get_usdxyz_balance_evm failed to get balance" >&2
+        echo "❌ PANIC: get_usdcon_balance_evm failed to get balance" >&2
         echo "   account: $account, token_address: $token_address" >&2
         echo "   output: $balance_output" >&2
         exit 1
@@ -41,12 +41,12 @@ get_usdxyz_balance_evm() {
 }
 
 # Display balances for Chain 3 (Connected EVM)
-# Usage: display_balances_connected_evm [usdxyz_token_address]
+# Usage: display_balances_connected_evm [usdcon_token_address]
 # Fetches and displays Requester and Solver balances on the Connected EVM chain
-# If usdxyz_token_address is provided, also displays USDcon balances
+# If usdcon_token_address is provided, also displays USDcon balances
 # Only displays if EVM chain is running (skips silently if it's not)
 display_balances_connected_evm() {
-    local usdxyz_addr="$1"
+    local usdcon_addr="$1"
     
     # Check if EVM chain is running
     if ! curl -s -X POST http://127.0.0.1:8545 \
@@ -90,7 +90,7 @@ display_balances_connected_evm() {
         solver_eth=$(echo "scale=4; $solver_evm / 1000000000000000000" | bc 2>/dev/null || echo "N/A")
     fi
     
-    if [ -n "$usdxyz_addr" ]; then
+    if [ -n "$usdcon_addr" ]; then
         # PANIC if we passed a token address but couldn't get account addresses
         if [ -z "$requester_addr" ] || [ -z "$solver_addr" ]; then
             log_and_echo "❌ PANIC: display_balances_connected_evm failed to get account addresses"
@@ -99,20 +99,20 @@ display_balances_connected_evm() {
             exit 1
         fi
         
-        local requester_usdxyz=$(get_usdxyz_balance_evm "$requester_addr" "$usdxyz_addr")
-        local solver_usdxyz=$(get_usdxyz_balance_evm "$solver_addr" "$usdxyz_addr")
+        local requester_usdcon=$(get_usdcon_balance_evm "$requester_addr" "$usdcon_addr")
+        local solver_usdcon=$(get_usdcon_balance_evm "$solver_addr" "$usdcon_addr")
         
         # PANIC if we passed a token address but couldn't get balances
-        if [ -z "$requester_usdxyz" ] || [ -z "$solver_usdxyz" ]; then
+        if [ -z "$requester_usdcon" ] || [ -z "$solver_usdcon" ]; then
             log_and_echo "❌ PANIC: display_balances_connected_evm failed to get USDcon balances"
-            log_and_echo "   usdxyz_addr: $usdxyz_addr"
-            log_and_echo "   requester_usdxyz: '$requester_usdxyz'"
-            log_and_echo "   solver_usdxyz: '$solver_usdxyz'"
+            log_and_echo "   usdcon_addr: $usdcon_addr"
+            log_and_echo "   requester_usdcon: '$requester_usdcon'"
+            log_and_echo "   solver_usdcon: '$solver_usdcon'"
             exit 1
         fi
         
-        log_and_echo "      Requester (Acc 1): ${requester_eth} ETH, $requester_usdxyz 10e-6.USDcon"
-        log_and_echo "      Solver (Acc 2): ${solver_eth} ETH, $solver_usdxyz 10e-6.USDcon"
+        log_and_echo "      Requester (Acc 1): ${requester_eth} ETH, $requester_usdcon 10e-6.USDcon"
+        log_and_echo "      Solver (Acc 2): ${solver_eth} ETH, $solver_usdcon 10e-6.USDcon"
     else
         log_and_echo "      Requester (Acc 1): ${requester_eth} ETH"
         log_and_echo "      Solver (Acc 2): ${solver_eth} ETH"

--- a/testing-infra/ci-e2e/util_evm.sh
+++ b/testing-infra/ci-e2e/util_evm.sh
@@ -8,9 +8,9 @@
 #
 # Note: This file depends on functions from util.sh (log, log_and_echo, setup_project_root, etc.)
 
-# Get USDxyz balance for an EVM account
-# Usage: get_usdxyz_balance_evm <account_address> <usdxyz_token_address>
-# Returns the USDxyz balance for the given account
+# Get USDcon balance for an EVM account
+# Usage: get_usdxyz_balance_evm <account_address> <usd_token_address>
+# Returns the USDcon balance for the given account
 # PANICS if inputs are missing or balance lookup fails
 get_usdxyz_balance_evm() {
     local account="$1"
@@ -70,7 +70,7 @@ display_balances_connected_evm() {
     local solver_evm_output=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ACCOUNT_INDEX=2 npx hardhat run scripts/get-account-balance.js --network localhost" 2>&1)
     local solver_evm=$(echo "$solver_evm_output" | grep -E '^[0-9]+$' | tail -1 | tr -d '\n' || echo "0")
     
-    # Get account addresses for USDxyz balance lookup
+    # Get account addresses for USDcon balance lookup
     local requester_addr=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ACCOUNT_INDEX=1 npx hardhat run scripts/get-account-address.js --network localhost" 2>&1 | grep -E '^0x[a-fA-F0-9]{40}$' | head -1)
     local solver_addr=$(nix develop "$PROJECT_ROOT" -c bash -c "cd '$PROJECT_ROOT/evm-intent-framework' && ACCOUNT_INDEX=2 npx hardhat run scripts/get-account-address.js --network localhost" 2>&1 | grep -E '^0x[a-fA-F0-9]{40}$' | head -1)
     
@@ -111,8 +111,8 @@ display_balances_connected_evm() {
             exit 1
         fi
         
-        log_and_echo "      Requester (Acc 1): ${requester_eth} ETH, $requester_usdxyz 10e-6.USDxyz"
-        log_and_echo "      Solver (Acc 2): ${solver_eth} ETH, $solver_usdxyz 10e-6.USDxyz"
+        log_and_echo "      Requester (Acc 1): ${requester_eth} ETH, $requester_usdxyz 10e-6.USDcon"
+        log_and_echo "      Solver (Acc 2): ${solver_eth} ETH, $solver_usdxyz 10e-6.USDcon"
     else
         log_and_echo "      Requester (Acc 1): ${requester_eth} ETH"
         log_and_echo "      Solver (Acc 2): ${solver_eth} ETH"

--- a/testing-infra/ci-e2e/util_evm.sh
+++ b/testing-infra/ci-e2e/util_evm.sh
@@ -43,7 +43,7 @@ get_usdxyz_balance_evm() {
 # Display balances for Chain 3 (Connected EVM)
 # Usage: display_balances_connected_evm [usdxyz_token_address]
 # Fetches and displays Requester and Solver balances on the Connected EVM chain
-# If usdxyz_token_address is provided, also displays USDxyz balances
+# If usdxyz_token_address is provided, also displays USDcon balances
 # Only displays if EVM chain is running (skips silently if it's not)
 display_balances_connected_evm() {
     local usdxyz_addr="$1"
@@ -104,7 +104,7 @@ display_balances_connected_evm() {
         
         # PANIC if we passed a token address but couldn't get balances
         if [ -z "$requester_usdxyz" ] || [ -z "$solver_usdxyz" ]; then
-            log_and_echo "❌ PANIC: display_balances_connected_evm failed to get USDxyz balances"
+            log_and_echo "❌ PANIC: display_balances_connected_evm failed to get USDcon balances"
             log_and_echo "   usdxyz_addr: $usdxyz_addr"
             log_and_echo "   requester_usdxyz: '$requester_usdxyz'"
             log_and_echo "   solver_usdxyz: '$solver_usdxyz'"

--- a/testing-infra/ci-e2e/util_mvm.sh
+++ b/testing-infra/ci-e2e/util_mvm.sh
@@ -511,9 +511,9 @@ initialize_solver_registry() {
     fi
 }
 
-# Get USDxyz metadata address
+# Get USDhub/USDcon metadata address
 # Usage: get_usdxyz_metadata <test_tokens_address> <chain_num>
-# Returns the USDxyz metadata object address
+# Returns the USDhub/USDcon metadata object address
 get_usdxyz_metadata() {
     local test_tokens_addr="$1"
     local chain_num="$2"
@@ -537,9 +537,9 @@ get_usdxyz_metadata() {
     echo "$metadata"
 }
 
-# Get USDxyz balance for an account
+# Get USDhub/USDcon balance for an account
 # Usage: get_usdxyz_balance <profile> <chain_num> <test_tokens_address>
-# Returns the USDxyz balance for the given profile
+# Returns the USDhub/USDcon balance for the given profile
 get_usdxyz_balance() {
     local profile="$1"
     local chain_num="$2"
@@ -584,7 +584,7 @@ get_usdxyz_balance() {
     echo "$balance"
 }
 
-# Assert USDxyz balance matches expected value or PANIC
+# Assert USDhub/USDcon balance matches expected value or PANIC
 # Usage: assert_usdxyz_balance <profile> <chain_num> <test_tokens_addr> <expected_balance> <checkpoint_name>
 # Example: assert_usdxyz_balance "solver-chain2" "2" "$TEST_TOKENS_CHAIN2_ADDRESS" "1000000" "post-mint"
 # Exits with error if balance doesn't match expected value
@@ -598,16 +598,16 @@ assert_usdxyz_balance() {
     local actual=$(get_usdxyz_balance "$profile" "$chain_num" "$test_tokens_addr")
     
     if [ -z "$actual" ]; then
-        log_and_echo "❌ PANIC at $checkpoint: Failed to get USDxyz balance for $profile"
+        log_and_echo "❌ PANIC at $checkpoint: Failed to get USDhub/USDcon balance for $profile"
         exit 1
     fi
     
     if [ "$actual" != "$expected" ]; then
-        log_and_echo "❌ PANIC at $checkpoint: $profile USDxyz balance mismatch!"
+        log_and_echo "❌ PANIC at $checkpoint: $profile USDhub/USDcon balance mismatch!"
         log_and_echo "   Expected: $expected, Actual: $actual"
         exit 1
     fi
-    log_and_echo "   ✅ $checkpoint: $profile has $actual USDxyz (expected: $expected)"
+    log_and_echo "   ✅ $checkpoint: $profile has $actual 10e-6 USDhub/USDcon (expected: $expected)"
     return 0
 }
 

--- a/testing-infra/ci-e2e/util_mvm.sh
+++ b/testing-infra/ci-e2e/util_mvm.sh
@@ -626,20 +626,20 @@ display_balances_hub() {
     log_and_echo "   Chain 1 (Hub):"
     
     if [ -n "$test_tokens_addr" ]; then
-        local requester_usdxyz=$(get_usdxyz_balance "requester-chain1" "1" "$test_tokens_addr")
-        local solver_usdxyz=$(get_usdxyz_balance "solver-chain1" "1" "$test_tokens_addr")
+        local requester_usdhub=$(get_usdxyz_balance "requester-chain1" "1" "$test_tokens_addr")
+        local solver_usdhub=$(get_usdxyz_balance "solver-chain1" "1" "$test_tokens_addr")
         
         # PANIC if we passed a token address but couldn't get balances
-        if [ -z "$requester_usdxyz" ] || [ -z "$solver_usdxyz" ]; then
+        if [ -z "$requester_usdhub" ] || [ -z "$solver_usdhub" ]; then
             log_and_echo "❌ PANIC: display_balances_hub failed to get USDhub balances"
             log_and_echo "   test_tokens_addr: $test_tokens_addr"
-            log_and_echo "   requester_usdxyz: '$requester_usdxyz'"
-            log_and_echo "   solver_usdxyz: '$solver_usdxyz'"
+            log_and_echo "   requester_usdhub: '$requester_usdhub'"
+            log_and_echo "   solver_usdhub: '$solver_usdhub'"
             exit 1
         fi
         
-        log_and_echo "      Requester: $requester1 Octas APT, $requester_usdxyz 10e-6.USDhub"
-        log_and_echo "      Solver:   $solver1 Octas APT, $solver_usdxyz 10e-6.USDhub"
+        log_and_echo "      Requester: $requester1 Octas APT, $requester_usdhub 10e-6.USDhub"
+        log_and_echo "      Solver:   $solver1 Octas APT, $solver_usdhub 10e-6.USDhub"
     else
         log_and_echo "      Requester: $requester1 Octas"
         log_and_echo "      Solver:   $solver1 Octas"
@@ -665,20 +665,20 @@ display_balances_connected_mvm() {
     log_and_echo "   Chain 2 (Connected MVM):"
     
     if [ -n "$test_tokens_addr" ]; then
-        local requester_usdxyz=$(get_usdxyz_balance "requester-chain2" "2" "$test_tokens_addr")
-        local solver_usdxyz=$(get_usdxyz_balance "solver-chain2" "2" "$test_tokens_addr")
+        local requester_usdcon=$(get_usdxyz_balance "requester-chain2" "2" "$test_tokens_addr")
+        local solver_usdcon=$(get_usdxyz_balance "solver-chain2" "2" "$test_tokens_addr")
         
         # PANIC if we passed a token address but couldn't get balances
-        if [ -z "$requester_usdxyz" ] || [ -z "$solver_usdxyz" ]; then
+        if [ -z "$requester_usdcon" ] || [ -z "$solver_usdcon" ]; then
             log_and_echo "❌ PANIC: display_balances_connected_mvm failed to get USDcon balances"
             log_and_echo "   test_tokens_addr: $test_tokens_addr"
-            log_and_echo "   requester_usdxyz: '$requester_usdxyz'"
-            log_and_echo "   solver_usdxyz: '$solver_usdxyz'"
+            log_and_echo "   requester_usdcon: '$requester_usdcon'"
+            log_and_echo "   solver_usdcon: '$solver_usdcon'"
             exit 1
         fi
         
-        log_and_echo "      Requester: $requester2 Octas APT, $requester_usdxyz 10e-6.USDcon"
-        log_and_echo "      Solver:   $solver2 Octas APT, $solver_usdxyz 10e-6.USDcon"
+        log_and_echo "      Requester: $requester2 Octas APT, $requester_usdcon 10e-6.USDcon"
+        log_and_echo "      Solver:   $solver2 Octas APT, $solver_usdcon 10e-6.USDcon"
     else
         log_and_echo "      Requester: $requester2 Octas"
         log_and_echo "      Solver:   $solver2 Octas"

--- a/testing-infra/ci-e2e/util_mvm.sh
+++ b/testing-infra/ci-e2e/util_mvm.sh
@@ -614,7 +614,7 @@ assert_usdxyz_balance() {
 # Display balances for Chain 1 (Hub)
 # Usage: display_balances_hub [test_tokens_address]
 # Fetches and displays Requester and Solver balances on the Hub chain
-# If test_tokens_address is provided, also displays USDxyz balances (PANICS if USDxyz lookup fails)
+# If test_tokens_address is provided, also displays USDhub balances (PANICS if lookup fails)
 # Note: Hub chain is always a Move VM chain, so this uses aptos commands
 display_balances_hub() {
     local test_tokens_addr="$1"
@@ -631,15 +631,15 @@ display_balances_hub() {
         
         # PANIC if we passed a token address but couldn't get balances
         if [ -z "$requester_usdxyz" ] || [ -z "$solver_usdxyz" ]; then
-            log_and_echo "❌ PANIC: display_balances_hub failed to get USDxyz balances"
+            log_and_echo "❌ PANIC: display_balances_hub failed to get USDhub balances"
             log_and_echo "   test_tokens_addr: $test_tokens_addr"
             log_and_echo "   requester_usdxyz: '$requester_usdxyz'"
             log_and_echo "   solver_usdxyz: '$solver_usdxyz'"
             exit 1
         fi
         
-        log_and_echo "      Requester: $requester1 Octas APT, $requester_usdxyz 10e-6.USDxyz"
-        log_and_echo "      Solver:   $solver1 Octas APT, $solver_usdxyz 10e-6.USDxyz"
+        log_and_echo "      Requester: $requester1 Octas APT, $requester_usdxyz 10e-6.USDhub"
+        log_and_echo "      Solver:   $solver1 Octas APT, $solver_usdxyz 10e-6.USDhub"
     else
         log_and_echo "      Requester: $requester1 Octas"
         log_and_echo "      Solver:   $solver1 Octas"
@@ -649,7 +649,7 @@ display_balances_hub() {
 # Display balances for Chain 2 (Connected Move VM)
 # Usage: display_balances_connected_mvm [test_tokens_address]
 # Fetches and displays Requester and Solver balances on the Connected Move VM chain
-# If test_tokens_address is provided, also displays USDxyz balances (PANICS if USDxyz lookup fails)
+# If test_tokens_address is provided, also displays USDcon balances (PANICS if lookup fails)
 # Only displays if Chain 2 profiles exist (skips silently if they don't)
 display_balances_connected_mvm() {
     local test_tokens_addr="$1"
@@ -670,15 +670,15 @@ display_balances_connected_mvm() {
         
         # PANIC if we passed a token address but couldn't get balances
         if [ -z "$requester_usdxyz" ] || [ -z "$solver_usdxyz" ]; then
-            log_and_echo "❌ PANIC: display_balances_connected_mvm failed to get USDxyz balances"
+            log_and_echo "❌ PANIC: display_balances_connected_mvm failed to get USDcon balances"
             log_and_echo "   test_tokens_addr: $test_tokens_addr"
             log_and_echo "   requester_usdxyz: '$requester_usdxyz'"
             log_and_echo "   solver_usdxyz: '$solver_usdxyz'"
             exit 1
         fi
         
-        log_and_echo "      Requester: $requester2 Octas APT, $requester_usdxyz 10e-6.USDxyz"
-        log_and_echo "      Solver:   $solver2 Octas APT, $solver_usdxyz 10e-6.USDxyz"
+        log_and_echo "      Requester: $requester2 Octas APT, $requester_usdxyz 10e-6.USDcon"
+        log_and_echo "      Solver:   $solver2 Octas APT, $solver_usdxyz 10e-6.USDcon"
     else
         log_and_echo "      Requester: $requester2 Octas"
         log_and_echo "      Solver:   $solver2 Octas"


### PR DESCRIPTION
# Standardize token naming: USDxyz → USDhub/USDcon

## Summary

Replace "USDxyz" with "USDhub" (hub chain) and "USDcon" (connected chain) across shell scripts and docs.

## Types of Changes

- Refactor
- Documentation

## Description

Renamed variables, functions, and files to use chain-specific terminology.
